### PR TITLE
feat: .htaccess 入門ガイドページを追加

### DIFF
--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+		<!-- OGP -->
+		<meta property="og:type" content="article">
+		<meta property="og:title" content=".htaccess とは？入門ガイド">
+		<meta property="og:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+		<meta property="og:locale" content="ja_JP">
+		<meta property="og:site_name" content=".htaccess Generator">
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:title" content=".htaccess とは？入門ガイド">
+		<meta name="twitter:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+
+		<title>.htaccess とは？入門ガイド | .htaccess Generator</title>
+		<script>
+			try {
+				if (window.localStorage && localStorage.getItem('htaccess-theme') === 'dark') {
+					document.documentElement.setAttribute('data-theme', 'dark');
+				}
+			} catch (e) {
+				// localStorage is unavailable (e.g. disabled or restricted); fall back to default theme
+			}
+		</script>
+		<link rel="stylesheet" href="../assets/css/style.css">
+	</head>
+
+	<body>
+		<div class="app-wrapper">
+
+			<header class="app-header">
+				<h1><a href="../">.htaccess Generator</a></h1>
+				<p>.htaccess とは？入門ガイド</p>
+				<div class="header-actions">
+					<a href="../" class="header-link"><span aria-hidden="true">←</span> ジェネレーター</a>
+					<button type="button" class="theme-toggle-btn" aria-label="ダークモードに切り替え" aria-pressed="false">
+						<span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+						<span class="theme-toggle-label">ダーク</span>
+					</button>
+				</div>
+			</header>
+
+			<main>
+				<article class="card article">
+
+					<!-- .htaccess とは？ -->
+					<section>
+						<h2>.htaccess とは？</h2>
+						<p><strong>Apache ウェブサーバーのディレクトリ単位の設定ファイル</strong>。</p>
+						<p>ファイル名は <code>.htaccess</code>（ドット始まり）で、特定のディレクトリに置くとそのディレクトリ以下すべての挙動を制御できる。</p>
+						<p>通常の Apache 設定は <code>httpd.conf</code> というサーバー全体の設定ファイルで行うが、レンタルサーバーでは
+							<code>httpd.conf</code> を直接編集できない。</p>
+						<p><code>.htaccess</code> はサーバー管理者の権限がなくても、ディレクトリ単位で設定を上書きできる仕組みとして用意されている。</p>
+
+						<h3>配置場所と効果範囲</h3>
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>配置場所</th>
+										<th>効果範囲</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>サイトルート（<code>/public_html/</code>）</td>
+										<td>サイト全体</td>
+									</tr>
+									<tr>
+										<td><code>/public_html/blog/</code></td>
+										<td><code>/blog/</code> 以下のみ</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+						<blockquote>
+							<p>通常は WordPress がインストールされているサイトルートに 1 つ置くだけで OK。</p>
+						</blockquote>
+					</section>
+
+					<hr class="divider">
+
+					<!-- .htaccess でできること -->
+					<section>
+						<h2>.htaccess でできること</h2>
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>機能</th>
+										<th>例</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>リクエストの書き換え</td>
+										<td>HTTP → HTTPS へ 301 リダイレクト、URL 正規化</td>
+									</tr>
+									<tr>
+										<td>アクセス制限</td>
+										<td>特定の IP やボット UA をブロック（403 を返す）</td>
+									</tr>
+									<tr>
+										<td>ファイル保護</td>
+										<td><code>wp-config.php</code> や <code>.htaccess</code> 自体への直接アクセスを拒否</td>
+									</tr>
+									<tr>
+										<td>レスポンスヘッダーの追加</td>
+										<td>HSTS・CSP・X-Frame-Options などセキュリティヘッダーの付与</td>
+									</tr>
+									<tr>
+										<td>キャッシュ制御</td>
+										<td>画像・CSS・JS のブラウザキャッシュ有効期限を設定</td>
+									</tr>
+									<tr>
+										<td>圧縮</td>
+										<td>Gzip 圧縮でレスポンスサイズを削減</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</section>
+
+					<hr class="divider">
+
+					<!-- 使える環境・使えない環境 -->
+					<section>
+						<h2>使える環境・使えない環境</h2>
+						<p><code>.htaccess</code> は <strong>Apache ウェブサーバー専用</strong>の機能。国内の主要レンタルサーバーはほぼ Apache
+							のため、そのまま使える。</p>
+
+						<h3>主要レンタルサーバーの対応状況</h3>
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>サーバー</th>
+										<th>対応</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>エックスサーバー</td>
+										<td>✅ 使える</td>
+									</tr>
+									<tr>
+										<td>ConoHa WING</td>
+										<td>✅ 使える</td>
+									</tr>
+									<tr>
+										<td>シン・レンタルサーバー</td>
+										<td>✅ 使える</td>
+									</tr>
+									<tr>
+										<td>さくらインターネット</td>
+										<td>✅ 使える</td>
+									</tr>
+									<tr>
+										<td>ロリポップ</td>
+										<td>✅ 使える</td>
+									</tr>
+									<tr>
+										<td>VPS（Nginx を自前構築）</td>
+										<td>❌ 使えない</td>
+									</tr>
+									<tr>
+										<td>KUSANAGI（Nginx モード）</td>
+										<td>❌ 使えない</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+						<blockquote>
+							<p><strong>Nginx 環境の場合:</strong> 設定は <code>nginx.conf</code> や <code>server</code>
+								ブロックで行う。書き方は違うが概念は共通なので、<code>.htaccess</code> の知識は無駄にならない。</p>
+						</blockquote>
+					</section>
+
+					<hr class="divider">
+
+					<!-- WordPress との関係 -->
+					<section>
+						<h2>WordPress との関係</h2>
+
+						<h3>WordPress が自動生成するブロック</h3>
+						<p>WordPress の「設定 → パーマリンク設定」を保存すると、<code>.htaccess</code> に以下のブロックが自動生成される。</p>
+						<pre class="article-code"><code># BEGIN WordPress
+# "BEGIN WordPress" から "END WordPress" までのディレクティブ (行) は
+# 動的に生成され、WordPress フィルターによってのみ修正が可能です。
+# これらのマーカー間にあるディレクティブへの変更はすべて上書きされます。
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress</code></pre>
+
+						<h3>カスタムルールを書く場所</h3>
+						<p><code># BEGIN WordPress</code> 〜 <code># END WordPress</code> の間は <strong>WordPress
+								が自動的に上書き</strong>するため、直接編集してはいけない。カスタムルールはこのブロックの<strong>外（上）</strong>に追記する。</p>
+						<pre class="article-code"><code># ✅ ここにカスタムルールを書く（WordPress ブロックより上）
+
+# 例: HTTPS リダイレクト
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on [NC]
+    RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</IfModule>
+
+# BEGIN WordPress
+# （WordPress 自動生成ブロック — 触らない）
+...
+# END WordPress</code></pre>
+
+						<blockquote>
+							<p>Wordfence・EWWW Image Optimizer などのプラグインが生成するブロックも同様に触らない。</p>
+						</blockquote>
+					</section>
+
+					<hr class="divider">
+
+					<!-- 基本構文の3つの柱 -->
+					<section>
+						<h2>基本構文の 3 つの柱</h2>
+						<p><code>.htaccess</code> に登場するコードのほとんどは、次の 3 つのディレクティブの組み合わせで成り立っている。</p>
+
+						<pre class="article-code"><code>IfModule      → 「このモジュールは使える？」（安全装置）
+ └ RewriteCond  → 「この条件に合致する？」（if 文）
+   └ RewriteRule  → 「条件を満たしたのでこう処理する」（実行）</code></pre>
+
+						<h3><code>&lt;IfModule&gt;</code> — モジュールの安全装置</h3>
+						<p>指定した Apache モジュールが有効な場合にのみ、中のディレクティブを実行する。モジュールが存在しない環境で <code>&lt;IfModule&gt;</code> なしに書くと
+							<strong>500 エラーでサイトダウン</strong>になるため、必ず囲む。
+						</p>
+						<pre class="article-code"><code><IfModule mod_rewrite.c>
+    # mod_rewrite が有効なときだけ実行される
+    RewriteEngine On
+    ...
+</IfModule></code></pre>
+
+						<h3><code>RewriteCond</code> — 条件（if 文）</h3>
+						<p>直後の <code>RewriteRule</code> を実行するかどうかを判定する条件文。複数行並べるとデフォルトで <strong>AND
+								条件</strong>（すべて満たしたときだけ実行）。</p>
+						<pre class="article-code"><code>RewriteCond %{テスト文字列} パターン [フラグ]</code></pre>
+
+						<h3><code>RewriteRule</code> — 処理の実行</h3>
+						<p>条件を満たした場合に URL の書き換えやリダイレクトを実行する。</p>
+						<pre class="article-code"><code>RewriteRule パターン 置換先 [フラグ]</code></pre>
+
+						<blockquote>
+							<p>ディレクティブとフラグの詳細は <a href="../directives-guide/">ディレクティブ・フラグ解説ガイド</a> で解説している。</p>
+						</blockquote>
+					</section>
+
+					<hr class="divider">
+
+					<!-- 注意事項 -->
+					<section>
+						<h2>注意事項</h2>
+
+						<h3>編集前に必ずバックアップを取る</h3>
+						<p><code>.htaccess</code> の記述ミスは <strong>即座に 500 エラー（サイトダウン）</strong>
+							につながる。編集前にかならずバックアップを取っておくこと。</p>
+
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>バックアップ方法</th>
+										<th>手順</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>FTP / ファイルマネージャー</td>
+										<td>既存の <code>.htaccess</code> をダウンロードしてローカルに保存</td>
+									</tr>
+									<tr>
+										<td>ファイル名を変えてコピー</td>
+										<td>サーバー上で <code>.htaccess.bak</code> などにリネームコピー</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+
+						<h3>500 エラーが出たときのリカバリ</h3>
+						<p>編集後に 500 エラーが発生したら、バックアップファイルを元の名前に戻せばサイトは復旧する。詳しいリカバリ手順は <a
+								href="../recovery-guide/">リカバリ方法ガイド</a> を参照。</p>
+					</section>
+
+					<!-- ジェネレーターへ戻る -->
+					<div class="article-back">
+						<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+					</div>
+
+				</article>
+			</main>
+
+		</div>
+
+		<script type="module" src="../assets/js/guide.js"></script>
+	</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
 								aria-hidden="true">▾</span>
 						</button>
 						<ul class="dropdown-menu" id="guide-nav-menu" aria-hidden="true">
+							<li><a href="htaccess-basics-guide/">.htaccess 入門</a></li>
 							<li><a href="directives-guide/">ディレクティブ・フラグ解説</a></li>
 							<li><a href="security-headers-guide/">セキュリティヘッダー</a></li>
 							<li><a href="cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>


### PR DESCRIPTION
## 概要

初めて `.htaccess` に触れるユーザー向けの入門ガイドページ（`htaccess-basics-guide/`）を追加。

## 変更内容

- `htaccess-basics-guide/index.html` を新規作成
  - `.htaccess` とは？（配置場所・効果範囲）
  - できること（リライト・アクセス制限・セキュリティヘッダー・キャッシュ制御・圧縮）
  - 使える環境・使えない環境（主要レンタルサーバー対応表）
  - WordPress との関係（`# BEGIN WordPress` ブロックの扱い・カスタムルールの書き場所）
  - 基本構文の 3 つの柱（`IfModule` / `RewriteCond` / `RewriteRule`）
  - 注意事項（バックアップ必須・リカバリガイドへのリンク）
- `index.html` のガイドドロップダウンに「.htaccess 入門」を先頭エントリとして追加

## テスト

- [x] ガイドページが正常に表示される
- [x] ドロップダウンから `.htaccess 入門` に遷移できる
- [x] ダークモード切り替えが動作する
- [x] 内部リンク（ディレクティブ解説・リカバリガイド）が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)