### PR TITLE
docs: セキュリティヘッダーガイドにコンテンツを追加 (#33)

### DIFF
--- a/security-headers-guide/index.html
+++ b/security-headers-guide/index.html
@@ -492,7 +492,7 @@ Header always set Content-Security-Policy-Report-Only "default-src 'self'; repor
 						<p>空の括弧 <code>()</code> はそのディレクティブを完全に無効化することを意味する（すべてのオリジンからの使用を禁止）。</p>
 
 						<h3>制御可能な機能一覧</h3>
-						<p>ジェネレーターでは以下の機能を個別に ON/OFF できる。チェック ON で制限（<code>feature=()</code> を出力）、OFF でポリシーから除外（ブラウザデフォルトで許可）。</p>
+						<p>ジェネレーターでは以下の機能を個別に ON/OFF できる。チェック ON で制限（<code>feature=()</code> を出力）、OFF でポリシーから除外（ブラウザデフォルトで許可）。なお <code>geolocation</code> のみ例外で、ON/OFF の 2 択ではなく「完全無効化 / Google マップ許可 / ポリシーから除外」の 3 段階で設定できる。</p>
 						<div class="table-wrap">
 							<table>
 								<thead>
@@ -561,7 +561,7 @@ Header always set Content-Security-Policy-Report-Only "default-src 'self'; repor
 									</tr>
 									<tr>
 										<td>Google マップ許可</td>
-										<td><code>geolocation=(self "https://www.google.com")</code></td>
+										<td><code>geolocation=(self \"https://www.google.com\")</code></td>
 										<td>Google マップの「現在地を表示」機能を使うサイト</td>
 									</tr>
 									<tr>


### PR DESCRIPTION
## 概要

セキュリティヘッダーのガイドページに不足していたコンテンツを追加する。

closes #33

## 変更内容

### ① イントロセクション追加（「セキュリティヘッダーとは」）

- セキュリティヘッダーの概要と、なぜ `.htaccess` で設定するのかを説明
- 設定するメリット（コード変更不要・脆弱性スキャンの評価向上・プラグイン脆弱性の影響局限など）を追記
- 注意点・デメリット（CSP の設定ミスリスク・プラグインとの競合・HSTS の取り消し困難）を追記
- ジェネレーターで設定できるヘッダー一覧テーブルを追加

### ② CSP セクションに「管理画面用 CSP 分岐」の説明を追加

- `cspAdminSplit` オプションで生成される `<If>` 条件の出力例を追加
- 管理画面側の固定 CSP（`ADMIN_CSP`）が `unsafe-inline` / `unsafe-eval` を許可している理由を説明

### ③ Permissions-Policy の `geolocation` に Google マップ許可オプションの説明を追加

- `完全無効化` / `Google マップ許可` / `ポリシーから除外` の 3 段階設定をテーブルで整理
- `Google マップ許可` で生成される `geolocation=(self "https://www.google.com")` の用途を説明

## 変更ファイル

- `security-headers-guide/index.html`