### PR TITLE
fix: X-Forwarded-Proto を HTTPS リダイレクトのサブオプションに従属させる (#52)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -57,6 +57,7 @@ const elBlockBackdoors = document.querySelector('[name="blockBackdoors"]');
 const elBlockWpNesting = document.querySelector('[name="blockWpNesting"]');
 const elBlockWpIncludesDir = document.querySelector('[name="blockWpIncludesDir"]');
 const elHttpsRedirect = document.querySelector('[name="httpsRedirect"]');
+const elHttpsSubFields = document.querySelector('#https-sub-fields');
 const elXForwardedProto = document.querySelector('[name="xForwardedProto"]');
 const elBlockBadQuery = document.querySelector('[name="blockBadQuery"]');
 
@@ -514,6 +515,19 @@ const updateConditionalFields = () => {
 	}
 	if (elIpBlockHint) {
 		elIpBlockHint.hidden = !(elIpBlockEnabled?.checked && !elIpBlockList?.value?.trim());
+	}
+
+	// HTTPS リダイレクト サブフィールド
+	if (elHttpsSubFields) {
+		const httpsVisible = elHttpsRedirect?.checked ?? false;
+		elHttpsSubFields.hidden = !httpsVisible;
+		elHttpsRedirect?.setAttribute('aria-expanded', String(httpsVisible));
+		if (elXForwardedProto) {
+			elXForwardedProto.disabled = !httpsVisible;
+			if (!httpsVisible) {
+				elXForwardedProto.checked = false;
+			}
+		}
 	}
 
 	// ボットブロック サブフィールド

--- a/index.html
+++ b/index.html
@@ -334,16 +334,15 @@
 								<div class="toggle-row">
 									<label class="toggle-label" for="httpsRedirect">HTTPS リダイレクト</label>
 									<label class="toggle-switch">
-										<input type="checkbox" name="httpsRedirect" id="httpsRedirect">
+										<input type="checkbox" name="httpsRedirect" id="httpsRedirect"
+											aria-expanded="false" aria-controls="https-sub-fields">
 										<span class="toggle-track" aria-hidden="true"></span>
 									</label>
 								</div>
-								<div class="toggle-row">
-									<label class="toggle-label" for="xForwardedProto">X-Forwarded-Proto
-										判定（リバースプロキシ対応）</label>
-									<label class="toggle-switch">
+								<div class="sub-options" id="https-sub-fields" hidden>
+									<label class="sub-option-label">
 										<input type="checkbox" name="xForwardedProto" id="xForwardedProto">
-										<span class="toggle-track" aria-hidden="true"></span>
+										<span>X-Forwarded-Proto 判定（リバースプロキシ対応）</span>
 									</label>
 								</div>
 								<div class="toggle-row">


### PR DESCRIPTION
## 概要

`xForwardedProto` チェックボックスが `httpsRedirect` の ON/OFF に関わらず常に操作可能だった UX 問題を修正。

## 変更内容

- `xForwardedProto` を独立した toggle-row から `httpsRedirect` のサブオプション（`sub-options`）に移動
- `httpsRedirect` OFF 時はサブオプション全体を `hidden`、`xForwardedProto` を `disabled` + `checked = false` に連動
- `httpsRedirect` ON 時のみ `xForwardedProto` が操作可能になる
- 既存の `.sub-options` / `.sub-option-label` スタイルを流用（SCSS 変更なし）

## 対象ファイル

- `index.html` — xForwardedProto をサブオプション構造に移動、aria-expanded / aria-controls 追加
- `assets/js/main.js` — `elHttpsSubFields` 追加、`updateConditionalFields()` に HTTPS サブフィールド連動ロジック追加

Closes #52