### PR TITLE
fix: CSP 管理画面分岐パターンをサブディレクトリインストールに対応 (#73)

### DIFF
--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -557,10 +557,10 @@ const buildHeadersSection = (headers) => {
 
 			const adminCspValue = adminCspParts.join('; ');
 
-			directives.push(`\t<If "%{REQUEST_URI} !~ m#^/wp-(admin(?:/|$)|login\\.php)#">`);
+			directives.push(`\t<If "%{REQUEST_URI} !~ m#(?:^|/)wp-(admin(?:/|$)|login\\.php)#">`);
 			directives.push(`\t\tHeader always set ${cspHeaderName} "${cspValue}"`);
 			directives.push('\t</If>');
-			directives.push(`\t<If "%{REQUEST_URI} =~ m#^/wp-(admin(?:/|$)|login\\.php)#">`);
+			directives.push(`\t<If "%{REQUEST_URI} =~ m#(?:^|/)wp-(admin(?:/|$)|login\\.php)#">`);
 			directives.push(`\t\tHeader always set ${cspHeaderName} "${adminCspValue}"`);
 			directives.push('\t</If>');
 		}


### PR DESCRIPTION
## 概要

`<If>` ディレクティブの URI マッチパターンを修正し、WordPress をサブディレクトリにインストールしている環境でも管理画面 CSP が正しく適用されるようにする。

closes #73

## 変更内容

### `assets/js/generator.js`

`<If>` ディレクティブの正規表現パターンを変更。

**修正前**
```apache
<If "%{REQUEST_URI} !~ m#^/wp-(admin(?:/|$)|login\.php)#">
    Header always set Content-Security-Policy "..."
</If>
<If "%{REQUEST_URI} =~ m#^/wp-(admin(?:/|$)|login\.php)#">
    Header always set Content-Security-Policy "..."
</If>
```

**修正後**
```apache
<If "%{REQUEST_URI} !~ m#(?:^|/)wp-(admin(?:/|$)|login\.php)#">
    Header always set Content-Security-Policy "..."
</If>
<If "%{REQUEST_URI} =~ m#(?:^|/)wp-(admin(?:/|$)|login\.php)#">
    Header always set Content-Security-Policy "..."
</If>
```

## マッチ確認

| URI | 修正前 | 修正後 |
|---|---|---|
| `/wp-admin/` | ✅ | ✅ |
| `/blog/wp-admin/` | ❌ | ✅ |
| `/foo/bar/wp-admin/` | ❌ | ✅ |
| `/wp-login.php` | ✅ | ✅ |
| `/blog/wp-login.php` | ❌ | ✅ |