### PR TITLE
feat: ガイドページ多言語化（htaccess-basics-guide 先行実装）#78

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1283,3 +1283,7 @@ hr {
   border-top: 1px solid var(--border-color);
   text-align: center;
 }
+
+.lang-block[hidden] {
+  display: none;
+}

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -5,7 +5,7 @@
  */
 
 import { initTheme, setupThemeToggle, applyTheme } from './theme.js';
-import { initLang, getLang, setLang, applyTranslations, t } from './i18n.js';
+import { initLang, getLang, setLang, t } from './i18n.js';
 
 /**
  * lang-block の表示 / 非表示を現在の言語に合わせて切り替える
@@ -23,6 +23,11 @@ const applyLangBlocks = () => {
 	initTheme();
 	await initLang();
 	applyLangBlocks();
+
+	// initTheme() は initLang() より先に実行されるため、
+	// 現在のテーマを再適用してトグルボタンの文言/aria-label を現在言語で更新する
+	const currentIsDark = document.documentElement.dataset.theme === 'dark';
+	applyTheme(currentIsDark, t);
 	setupThemeToggle(t);
 
 	// lang toggle ボタン

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -4,7 +4,7 @@
  * テーマの初期化・切り替えボタンのイベント登録・i18n 対応を行う。
  */
 
-import { initTheme, setupThemeToggle, applyTheme } from './theme.js';
+import { initTheme, setupThemeToggle, applyTheme, DARK_THEME } from './theme.js';
 import { initLang, getLang, setLang, t } from './i18n.js';
 
 /**
@@ -13,9 +13,13 @@ import { initLang, getLang, setLang, t } from './i18n.js';
 const applyLangBlocks = () => {
 	const lang = getLang();
 	document.querySelectorAll('.lang-block').forEach((el) => {
-		el.dataset.lang === lang
-			? el.removeAttribute('hidden')
-			: el.setAttribute('hidden', '');
+		if (el.dataset.lang === lang) {
+			el.removeAttribute('hidden');
+			el.setAttribute('lang', el.dataset.lang);
+		} else {
+			el.setAttribute('hidden', '');
+			el.removeAttribute('lang');
+		}
 	});
 };
 
@@ -26,7 +30,7 @@ const applyLangBlocks = () => {
 
 	// initTheme() は initLang() より先に実行されるため、
 	// 現在のテーマを再適用してトグルボタンの文言/aria-label を現在言語で更新する
-	const currentIsDark = document.documentElement.dataset.theme === 'dark';
+	const currentIsDark = document.documentElement.getAttribute('data-theme') === DARK_THEME;
 	applyTheme(currentIsDark, t);
 	setupThemeToggle(t);
 
@@ -34,7 +38,7 @@ const applyLangBlocks = () => {
 	const langToggleBtn = document.querySelector('.lang-toggle-btn');
 	if (langToggleBtn) {
 		langToggleBtn.addEventListener('click', async () => {
-			const currentIsDark = document.documentElement.dataset.theme === 'dark';
+			const currentIsDark = document.documentElement.getAttribute('data-theme') === DARK_THEME;
 			const next = getLang() === 'ja' ? 'en' : 'ja';
 			await setLang(next);
 			applyLangBlocks();

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -24,16 +24,17 @@ const applyLangBlocks = () => {
 	await initLang();
 	applyTranslations();
 	applyLangBlocks();
-	setupThemeToggle();
+	setupThemeToggle(t);
 
 	// lang toggle ボタン
 	const langToggleBtn = document.querySelector('.lang-toggle-btn');
 	if (langToggleBtn) {
 		langToggleBtn.addEventListener('click', async () => {
+			const currentIsDark = document.documentElement.dataset.theme === 'dark';
 			const next = getLang() === 'ja' ? 'en' : 'ja';
 			await setLang(next);
 			applyLangBlocks();
-			applyTheme();
+			applyTheme(currentIsDark, t);
 
 			// ハンバーガーの aria-label を更新
 			const hamburgerBtn = document.querySelector('.hamburger-btn');
@@ -48,6 +49,10 @@ const applyLangBlocks = () => {
 	const hamburgerBtn = document.querySelector('.hamburger-btn');
 	const siteNav = document.querySelector('.site-nav');
 	if (hamburgerBtn && siteNav) {
+		// initLang() 完了後に初期 aria-label を正しい言語で設定する
+		const isOpen = hamburgerBtn.getAttribute('aria-expanded') === 'true';
+		hamburgerBtn.setAttribute('aria-label', isOpen ? t('nav.close') : t('nav.open'));
+
 		const setOpen = (val) => {
 			hamburgerBtn.setAttribute('aria-expanded', String(val));
 			hamburgerBtn.setAttribute('aria-label', val ? t('nav.close') : t('nav.open'));

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -22,7 +22,6 @@ const applyLangBlocks = () => {
 (async () => {
 	initTheme();
 	await initLang();
-	applyTranslations();
 	applyLangBlocks();
 	setupThemeToggle(t);
 

--- a/assets/js/guide.js
+++ b/assets/js/guide.js
@@ -1,49 +1,85 @@
 /**
  * guide.js — ガイドページ用エントリーポイント
  *
- * テーマの初期化・切り替えボタンのイベント登録を行う。
+ * テーマの初期化・切り替えボタンのイベント登録・i18n 対応を行う。
  */
 
-import { initTheme, setupThemeToggle } from './theme.js';
+import { initTheme, setupThemeToggle, applyTheme } from './theme.js';
+import { initLang, getLang, setLang, applyTranslations, t } from './i18n.js';
 
-initTheme();
-setupThemeToggle();
+/**
+ * lang-block の表示 / 非表示を現在の言語に合わせて切り替える
+ */
+const applyLangBlocks = () => {
+	const lang = getLang();
+	document.querySelectorAll('.lang-block').forEach((el) => {
+		el.dataset.lang === lang
+			? el.removeAttribute('hidden')
+			: el.setAttribute('hidden', '');
+	});
+};
 
-// ハンバーガーナビ — 開閉 / Esc / 外クリックで閉じる
-const hamburgerBtn = document.querySelector('.hamburger-btn');
-const siteNav = document.querySelector('.site-nav');
-if (hamburgerBtn && siteNav) {
-	const setOpen = (val) => {
-		hamburgerBtn.setAttribute('aria-expanded', String(val));
-		hamburgerBtn.setAttribute('aria-label', val ? 'メニューを閉じる' : 'メニューを開く');
-		if (val) {
-			siteNav.removeAttribute('hidden');
-			document.body.style.overflow = 'hidden';
-		} else {
-			siteNav.setAttribute('hidden', '');
-			document.body.style.overflow = '';
-		}
-	};
-	hamburgerBtn.addEventListener('click', () => {
-		setOpen(hamburgerBtn.getAttribute('aria-expanded') !== 'true');
-	});
-	document.addEventListener('keydown', (e) => {
-		if (e.key === 'Escape' && hamburgerBtn.getAttribute('aria-expanded') === 'true') {
-			e.preventDefault();
-			setOpen(false);
-			hamburgerBtn.focus();
-		}
-	});
-	siteNav.addEventListener('click', (e) => {
-		if (!e.target.closest('.site-nav-card')) {
-			setOpen(false);
-			hamburgerBtn.focus();
-		}
-	});
-}
+(async () => {
+	initTheme();
+	await initLang();
+	applyTranslations();
+	applyLangBlocks();
+	setupThemeToggle();
 
-// フッター年の動的更新
-const elFooterYear = document.getElementById('footer-year');
-if (elFooterYear) {
-	elFooterYear.textContent = new Date().getFullYear();
-}
+	// lang toggle ボタン
+	const langToggleBtn = document.querySelector('.lang-toggle-btn');
+	if (langToggleBtn) {
+		langToggleBtn.addEventListener('click', async () => {
+			const next = getLang() === 'ja' ? 'en' : 'ja';
+			await setLang(next);
+			applyLangBlocks();
+			applyTheme();
+
+			// ハンバーガーの aria-label を更新
+			const hamburgerBtn = document.querySelector('.hamburger-btn');
+			if (hamburgerBtn) {
+				const isOpen = hamburgerBtn.getAttribute('aria-expanded') === 'true';
+				hamburgerBtn.setAttribute('aria-label', isOpen ? t('nav.close') : t('nav.open'));
+			}
+		});
+	}
+
+	// ハンバーガーナビ — 開閉 / Esc / 外クリックで閉じる
+	const hamburgerBtn = document.querySelector('.hamburger-btn');
+	const siteNav = document.querySelector('.site-nav');
+	if (hamburgerBtn && siteNav) {
+		const setOpen = (val) => {
+			hamburgerBtn.setAttribute('aria-expanded', String(val));
+			hamburgerBtn.setAttribute('aria-label', val ? t('nav.close') : t('nav.open'));
+			if (val) {
+				siteNav.removeAttribute('hidden');
+				document.body.style.overflow = 'hidden';
+			} else {
+				siteNav.setAttribute('hidden', '');
+				document.body.style.overflow = '';
+			}
+		};
+		hamburgerBtn.addEventListener('click', () => {
+			setOpen(hamburgerBtn.getAttribute('aria-expanded') !== 'true');
+		});
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape' && hamburgerBtn.getAttribute('aria-expanded') === 'true') {
+				e.preventDefault();
+				setOpen(false);
+				hamburgerBtn.focus();
+			}
+		});
+		siteNav.addEventListener('click', (e) => {
+			if (!e.target.closest('.site-nav-card')) {
+				setOpen(false);
+				hamburgerBtn.focus();
+			}
+		});
+	}
+
+	// フッター年の動的更新
+	const elFooterYear = document.getElementById('footer-year');
+	if (elFooterYear) {
+		elFooterYear.textContent = new Date().getFullYear();
+	}
+})();

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -30,6 +30,7 @@ export const getLang = () => currentLang;
  * - data-i18n       → textContent
  * - data-i18n-html  → innerHTML（ロケールデータは信頼済みのため安全）
  * - data-i18n-aria-label → aria-label 属性
+ * - data-i18n-content    → content 属性（meta タグ用）
  */
 export const applyTranslations = () => {
 	document.querySelectorAll('[data-i18n]').forEach((el) => {
@@ -40,6 +41,9 @@ export const applyTranslations = () => {
 	});
 	document.querySelectorAll('[data-i18n-aria-label]').forEach((el) => {
 		el.setAttribute('aria-label', t(el.dataset.i18nAriaLabel));
+	});
+	document.querySelectorAll('[data-i18n-content]').forEach((el) => {
+		el.setAttribute('content', t(el.dataset.i18nContent));
 	});
 	document.documentElement.lang = currentLang;
 };

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -232,7 +232,7 @@ export default {
 	'gen.comment.blockPhp': '# Disable PHP file execution',
 
 	// Guide pages
-	'guide.lang.btn.text': 'JA',
-	'guide.lang.btn.label': 'Switch language (日本語に切り替え)',
 	'guide.htaccess-basics.subtitle': 'What is .htaccess? A Beginner\'s Guide',
+	'guide.htaccess-basics.title': 'What is .htaccess? A Beginner\'s Guide | .htaccess Generator',
+	'guide.htaccess-basics.description': 'A beginner\'s guide explaining what .htaccess is, what it can do, supported environments, its relationship with WordPress, and basic syntax.',
 };

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -235,4 +235,6 @@ export default {
 	'guide.htaccess-basics.subtitle': 'What is .htaccess? A Beginner\'s Guide',
 	'guide.htaccess-basics.title': 'What is .htaccess? A Beginner\'s Guide | .htaccess Generator',
 	'guide.htaccess-basics.description': 'A beginner\'s guide explaining what .htaccess is, what it can do, supported environments, its relationship with WordPress, and basic syntax.',
+	'guide.htaccess-basics.ogUrl': 'https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/?lang=en',
+	'guide.htaccess-basics.ogLocale': 'en_US',
 };

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -230,4 +230,8 @@ export default {
 	'gen.comment.ajaxExclude': '# Allow access to admin-ajax.php (for frontend Ajax)',
 	'gen.comment.upgradeIpExclude': '# Skip Basic Auth for upgrade.php from server internal IP (for auto-updates)',
 	'gen.comment.blockPhp': '# Disable PHP file execution',
+
+	// Guide pages
+	'guide.lang.btn.text': 'JA',
+	'guide.lang.btn.label': 'Switch language (日本語に切り替え)',
 };

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -234,4 +234,5 @@ export default {
 	// Guide pages
 	'guide.lang.btn.text': 'JA',
 	'guide.lang.btn.label': 'Switch language (日本語に切り替え)',
+	'guide.htaccess-basics.subtitle': 'What is .htaccess? A Beginner\'s Guide',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -234,4 +234,5 @@ export default {
 	// ガイドページ
 	'guide.lang.btn.text': 'EN',
 	'guide.lang.btn.label': '言語切り替え（Switch to English）',
+	'guide.htaccess-basics.subtitle': '.htaccess とは？入門ガイド',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -230,4 +230,8 @@ export default {
 	'gen.comment.ajaxExclude': '# admin-ajax.php へのアクセスを許可（フロントエンドの Ajax 用）',
 	'gen.comment.upgradeIpExclude': '# upgrade.php はサーバー内部 IP のみ Basic 認証をスキップ（自動更新用）',
 	'gen.comment.blockPhp': '# PHP 関連ファイルの実行を禁止',
+
+	// ガイドページ
+	'guide.lang.btn.text': 'EN',
+	'guide.lang.btn.label': '言語切り替え（Switch to English）',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -232,7 +232,7 @@ export default {
 	'gen.comment.blockPhp': '# PHP 関連ファイルの実行を禁止',
 
 	// ガイドページ
-	'guide.lang.btn.text': 'EN',
-	'guide.lang.btn.label': '言語切り替え（Switch to English）',
 	'guide.htaccess-basics.subtitle': '.htaccess とは？入門ガイド',
+	'guide.htaccess-basics.title': '.htaccess とは？入門ガイド | .htaccess Generator',
+	'guide.htaccess-basics.description': '.htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -235,4 +235,6 @@ export default {
 	'guide.htaccess-basics.subtitle': '.htaccess とは？入門ガイド',
 	'guide.htaccess-basics.title': '.htaccess とは？入門ガイド | .htaccess Generator',
 	'guide.htaccess-basics.description': '.htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド',
+	'guide.htaccess-basics.ogUrl': 'https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/',
+	'guide.htaccess-basics.ogLocale': 'ja_JP',
 };

--- a/assets/scss/_article.scss
+++ b/assets/scss/_article.scss
@@ -181,3 +181,7 @@
 	border-top: 1px solid var(--border-color);
 	text-align: center;
 }
+
+.lang-block[hidden] {
+	display: none;
+}

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -25,6 +25,11 @@
 		<meta name="license" content="https://creativecommons.org/licenses/by-nc-sa/4.0/">
 
 		<link rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+		<link rel="alternate" hreflang="ja" href="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/">
+		<link rel="alternate" hreflang="en"
+			href="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/?lang=en">
+		<link rel="alternate" hreflang="x-default"
+			href="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/">
 		<title>.htaccess とは？入門ガイド | .htaccess Generator</title>
 		<script>
 			try {
@@ -43,13 +48,18 @@
 	</head>
 
 	<body>
-		<a href="#main-content" class="skip-link">メインコンテンツへスキップ</a>
+		<a href="#main-content" class="skip-link" data-i18n="skip.link">メインコンテンツへスキップ</a>
 		<div class="app-wrapper">
 
 			<header class="app-header">
 				<h1><a href="../">.htaccess Generator</a><span class="h1-sub">for WordPress</span></h1>
 				<p>.htaccess とは？入門ガイド</p>
 				<div class="header-actions">
+					<button type="button" class="lang-toggle-btn" aria-label="言語切り替え（Switch to English）"
+						data-i18n-aria-label="guide.lang.btn.label">
+						<span class="lang-toggle-icon" aria-hidden="true">🌐</span>
+						<span class="lang-toggle-label" data-i18n="guide.lang.btn.text">EN</span>
+					</button>
 					<button type="button" class="theme-toggle-btn" aria-label="ダークモードに切り替え" aria-pressed="false">
 						<span class="theme-toggle-icon" aria-hidden="true">🌙</span>
 						<span class="theme-toggle-label">ダーク</span>
@@ -63,7 +73,7 @@
 				</div>
 			</header>
 
-			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション">
+			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション" data-i18n-aria-label="nav.aria">
 				<div class="site-nav-card">
 					<ul class="site-nav-list">
 						<li><a href="../"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14"
@@ -79,7 +89,7 @@
 						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
 						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/">リカバリ方法</a></li>
-						<li><a href="../terms/">利用規約</a></li>
+						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"
 									viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"
@@ -96,80 +106,161 @@
 
 					<!-- .htaccess とは？ -->
 					<section>
-						<h2>.htaccess とは？</h2>
-						<p><strong>Apache ウェブサーバーのディレクトリ単位の設定ファイル</strong>。</p>
-						<p>ファイル名は <code>.htaccess</code>（ドット始まり）で、特定のディレクトリに置くとそのディレクトリ以下すべての挙動を制御できる。</p>
-						<p>通常の Apache 設定は <code>httpd.conf</code> というサーバー全体の設定ファイルで行うが、レンタルサーバーでは
-							<code>httpd.conf</code> を直接編集できない。
-						</p>
-						<p><code>.htaccess</code> はサーバー管理者の権限がなくても、ディレクトリ単位で設定を上書きできる仕組みとして用意されている。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>.htaccess とは？</h2>
+							<p><strong>Apache ウェブサーバーのディレクトリ単位の設定ファイル</strong>。</p>
+							<p>ファイル名は <code>.htaccess</code>（ドット始まり）で、特定のディレクトリに置くとそのディレクトリ以下すべての挙動を制御できる。</p>
+							<p>通常の Apache 設定は <code>httpd.conf</code> というサーバー全体の設定ファイルで行うが、レンタルサーバーでは
+								<code>httpd.conf</code> を直接編集できない。
+							</p>
+							<p><code>.htaccess</code> はサーバー管理者の権限がなくても、ディレクトリ単位で設定を上書きできる仕組みとして用意されている。</p>
 
-						<h3>配置場所と効果範囲</h3>
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>配置場所</th>
-										<th>効果範囲</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>サイトルート（<code>/public_html/</code>）</td>
-										<td>サイト全体</td>
-									</tr>
-									<tr>
-										<td><code>/public_html/blog/</code></td>
-										<td><code>/blog/</code> 以下のみ</td>
-									</tr>
-								</tbody>
-							</table>
+							<h3>配置場所と効果範囲</h3>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>配置場所</th>
+											<th>効果範囲</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>サイトルート（<code>/public_html/</code>）</td>
+											<td>サイト全体</td>
+										</tr>
+										<tr>
+											<td><code>/public_html/blog/</code></td>
+											<td><code>/blog/</code> 以下のみ</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<blockquote>
+								<p>通常は WordPress がインストールされているサイトルートに 1 つ置くだけで OK。</p>
+							</blockquote>
 						</div>
-						<blockquote>
-							<p>通常は WordPress がインストールされているサイトルートに 1 つ置くだけで OK。</p>
-						</blockquote>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>What is .htaccess?</h2>
+							<p><strong>A per-directory configuration file for the Apache web server</strong>.</p>
+							<p>The file is named <code>.htaccess</code> (dot prefix). Placing it in a directory controls
+								the behavior of that directory and everything beneath it.</p>
+							<p>Normally, Apache settings are managed in <code>httpd.conf</code>, the server-wide
+								configuration file, but shared hosting providers typically do not allow direct access to
+								it.</p>
+							<p><code>.htaccess</code> exists as a mechanism that lets you override settings on a
+								per-directory basis without needing server-administrator privileges.</p>
+
+							<h3>Placement and scope</h3>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Location</th>
+											<th>Scope</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>Site root (<code>/public_html/</code>)</td>
+											<td>Entire site</td>
+										</tr>
+										<tr>
+											<td><code>/public_html/blog/</code></td>
+											<td><code>/blog/</code> and below only</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<blockquote>
+								<p>In most cases, a single file placed in the site root where WordPress is installed is
+									all you need.</p>
+							</blockquote>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<!-- .htaccess でできること -->
 					<section>
-						<h2>.htaccess でできること</h2>
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>機能</th>
-										<th>例</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>リクエストの書き換え</td>
-										<td>HTTP → HTTPS へ 301 リダイレクト、URL 正規化</td>
-									</tr>
-									<tr>
-										<td>アクセス制限</td>
-										<td>特定の IP やボット UA をブロック（403 を返す）</td>
-									</tr>
-									<tr>
-										<td>ファイル保護</td>
-										<td><code>wp-config.php</code> や <code>.htaccess</code> 自体への直接アクセスを拒否</td>
-									</tr>
-									<tr>
-										<td>レスポンスヘッダーの追加</td>
-										<td>HSTS・CSP・X-Frame-Options などセキュリティヘッダーの付与</td>
-									</tr>
-									<tr>
-										<td>キャッシュ制御</td>
-										<td>画像・CSS・JS のブラウザキャッシュ有効期限を設定</td>
-									</tr>
-									<tr>
-										<td>圧縮</td>
-										<td>Gzip 圧縮でレスポンスサイズを削減</td>
-									</tr>
-								</tbody>
-							</table>
+						<div class="lang-block" data-lang="ja">
+							<h2>.htaccess でできること</h2>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>機能</th>
+											<th>例</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>リクエストの書き換え</td>
+											<td>HTTP → HTTPS へ 301 リダイレクト、URL 正規化</td>
+										</tr>
+										<tr>
+											<td>アクセス制限</td>
+											<td>特定の IP やボット UA をブロック（403 を返す）</td>
+										</tr>
+										<tr>
+											<td>ファイル保護</td>
+											<td><code>wp-config.php</code> や <code>.htaccess</code> 自体への直接アクセスを拒否</td>
+										</tr>
+										<tr>
+											<td>レスポンスヘッダーの追加</td>
+											<td>HSTS・CSP・X-Frame-Options などセキュリティヘッダーの付与</td>
+										</tr>
+										<tr>
+											<td>キャッシュ制御</td>
+											<td>画像・CSS・JS のブラウザキャッシュ有効期限を設定</td>
+										</tr>
+										<tr>
+											<td>圧縮</td>
+											<td>Gzip 圧縮でレスポンスサイズを削減</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>What .htaccess can do</h2>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Feature</th>
+											<th>Example</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>Request rewriting</td>
+											<td>301 redirect from HTTP to HTTPS, URL normalization</td>
+										</tr>
+										<tr>
+											<td>Access restriction</td>
+											<td>Block specific IPs or bot User-Agents (return 403)</td>
+										</tr>
+										<tr>
+											<td>File protection</td>
+											<td>Deny direct access to <code>wp-config.php</code> or
+												<code>.htaccess</code> itself</td>
+										</tr>
+										<tr>
+											<td>Response header injection</td>
+											<td>Add security headers: HSTS, CSP, X-Frame-Options, etc.</td>
+										</tr>
+										<tr>
+											<td>Cache control</td>
+											<td>Set browser cache expiry for images, CSS, and JS</td>
+										</tr>
+										<tr>
+											<td>Compression</td>
+											<td>Reduce response size with Gzip compression</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
 					</section>
 
@@ -177,61 +268,116 @@
 
 					<!-- 使える環境・使えない環境 -->
 					<section>
-						<h2>使える環境・使えない環境</h2>
-						<p><code>.htaccess</code> は <strong>Apache ウェブサーバー専用</strong>の機能。国内の主要レンタルサーバーはほぼ Apache
-							のため、そのまま使える。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>使える環境・使えない環境</h2>
+							<p><code>.htaccess</code> は <strong>Apache ウェブサーバー専用</strong>の機能。国内の主要レンタルサーバーはほぼ Apache
+								のため、そのまま使える。</p>
 
-						<h3>主要レンタルサーバーの対応状況</h3>
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>サーバー</th>
-										<th>対応</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>エックスサーバー</td>
-										<td>✅ 使える</td>
-									</tr>
-									<tr>
-										<td>ConoHa WING</td>
-										<td>✅ 使える</td>
-									</tr>
-									<tr>
-										<td>シン・レンタルサーバー</td>
-										<td>✅ 使える</td>
-									</tr>
-									<tr>
-										<td>さくらインターネット</td>
-										<td>✅ 使える</td>
-									</tr>
-									<tr>
-										<td>ロリポップ</td>
-										<td>✅ 使える</td>
-									</tr>
-									<tr>
-										<td>VPS（Nginx を自前構築）</td>
-										<td>❌ 使えない</td>
-									</tr>
-									<tr>
-										<td>KUSANAGI（Nginx モード）</td>
-										<td>❌ 使えない</td>
-									</tr>
-								</tbody>
-							</table>
+							<h3>主要レンタルサーバーの対応状況</h3>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>サーバー</th>
+											<th>対応</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>エックスサーバー</td>
+											<td>✅ 使える</td>
+										</tr>
+										<tr>
+											<td>ConoHa WING</td>
+											<td>✅ 使える</td>
+										</tr>
+										<tr>
+											<td>シン・レンタルサーバー</td>
+											<td>✅ 使える</td>
+										</tr>
+										<tr>
+											<td>さくらインターネット</td>
+											<td>✅ 使える</td>
+										</tr>
+										<tr>
+											<td>ロリポップ</td>
+											<td>✅ 使える</td>
+										</tr>
+										<tr>
+											<td>VPS（Nginx を自前構築）</td>
+											<td>❌ 使えない</td>
+										</tr>
+										<tr>
+											<td>KUSANAGI（Nginx モード）</td>
+											<td>❌ 使えない</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<blockquote>
+								<p><strong>Nginx 環境の場合:</strong> 設定は <code>nginx.conf</code> や <code>server</code>
+									ブロックで行う。書き方は違うが概念は共通なので、<code>.htaccess</code> の知識は無駄にならない。</p>
+							</blockquote>
 						</div>
-						<blockquote>
-							<p><strong>Nginx 環境の場合:</strong> 設定は <code>nginx.conf</code> や <code>server</code>
-								ブロックで行う。書き方は違うが概念は共通なので、<code>.htaccess</code> の知識は無駄にならない。</p>
-						</blockquote>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>Supported and unsupported environments</h2>
+							<p><code>.htaccess</code> is an <strong>Apache-only</strong> feature. Most major Japanese
+								shared hosting services run Apache, so it works out of the box.</p>
+
+							<h3>Compatibility of major hosting providers</h3>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Provider</th>
+											<th>Support</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>Xserver</td>
+											<td>✅ Supported</td>
+										</tr>
+										<tr>
+											<td>ConoHa WING</td>
+											<td>✅ Supported</td>
+										</tr>
+										<tr>
+											<td>Shin Rental Server</td>
+											<td>✅ Supported</td>
+										</tr>
+										<tr>
+											<td>Sakura Internet</td>
+											<td>✅ Supported</td>
+										</tr>
+										<tr>
+											<td>Lolipop</td>
+											<td>✅ Supported</td>
+										</tr>
+										<tr>
+											<td>VPS (Nginx self-hosted)</td>
+											<td>❌ Not supported</td>
+										</tr>
+										<tr>
+											<td>KUSANAGI (Nginx mode)</td>
+											<td>❌ Not supported</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<blockquote>
+								<p><strong>On Nginx:</strong> Configuration is done in <code>nginx.conf</code> or a
+									<code>server</code> block. The syntax differs, but the concepts overlap, so your
+									<code>.htaccess</code> knowledge still applies.</p>
+							</blockquote>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<!-- WordPress との関係 -->
 					<section>
+						<div class="lang-block" data-lang="ja">
 						<h2>WordPress との関係</h2>
 
 						<h3>WordPress が自動生成するブロック</h3>
@@ -285,12 +431,62 @@ RewriteRule . /index.php [L]
 								Cache 等）も WordPress ブロックと同様に直接編集しない。
 							</p>
 						</blockquote>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+						<h2>Relationship with WordPress</h2>
+
+						<h3>The block WordPress auto-generates</h3>
+						<p>When you save settings under <strong>Settings → Permalinks</strong> in WordPress, the following block is automatically written to <code>.htaccess</code>.</p>
+						<pre class="article-code"><code># BEGIN WordPress
+# The directives (lines) between "BEGIN WordPress" and "END WordPress"
+# are dynamically generated, and should only be modified via WordPress filters.
+# Any changes to the directives between these markers will be overwritten.
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress</code></pre>
+						<blockquote>
+							<p><strong>Note:</strong>
+								The line <code>RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]</code> was added in WordPress 6.0 to fix a bug where Apache strips the <code>Authorization</code> header, which affects the REST API and Application Passwords. The exact content of the auto-generated block may vary between WordPress versions.
+							</p>
+						</blockquote>
+
+						<h3>Where to put your custom rules</h3>
+						<p>Everything between <code># BEGIN WordPress</code> and <code># END WordPress</code> is <strong>automatically overwritten by WordPress</strong> — never edit it directly. Add your custom rules <strong>above</strong> the block.</p>
+						<pre class="article-code"><code># ✅ Write your custom rules here (above the WordPress block)
+
+# Example: HTTPS redirect
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on [NC]
+    RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</IfModule>
+
+# ⚠️ Also leave plugin-generated blocks untouched (Wordfence, EWWW, etc.)
+# ...
+
+# BEGIN WordPress
+# (Auto-generated by WordPress — do not edit)
+...
+# END WordPress</code></pre>
+						<blockquote>
+							<p>The typical order is: custom rules → plugin-generated blocks → <code># BEGIN WordPress</code>. Treat plugin-generated blocks (Wordfence, EWWW Image Optimizer, Nginx Cache, etc.) the same way — never edit them directly.</p>
+						</blockquote>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<!-- 基本構文の3つの柱 -->
 					<section>
+						<div class="lang-block" data-lang="ja">
 						<h2>基本構文の 3 つの柱</h2>
 						<p><code>.htaccess</code> に登場するコードのほとんどは、次の 3 つのディレクティブの組み合わせで成り立っている。</p>
 
@@ -320,12 +516,42 @@ RewriteRule . /index.php [L]
 						<blockquote>
 							<p>ディレクティブとフラグの詳細は <a href="../directives-guide/">ディレクティブ・フラグ解説ガイド</a> で解説している。</p>
 						</blockquote>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+						<h2>The three pillars of .htaccess syntax</h2>
+						<p>Most of the code you encounter in <code>.htaccess</code> is built from combinations of these three directives.</p>
+
+						<pre class="article-code"><code>IfModule      → "Is this module available?" (safety guard)
+ └ RewriteCond  → "Does this condition match?" (if statement)
+   └ RewriteRule  → "Condition met — apply this transformation" (action)</code></pre>
+
+						<h3><code>&lt;IfModule&gt;</code> — safety guard for modules</h3>
+						<p>Executes the enclosed directives only when the specified Apache module is enabled. Writing module-dependent directives without <code>&lt;IfModule&gt;</code> on a server that lacks the module will cause a <strong>500 error and site outage</strong>, so always wrap them.</p>
+						<pre class="article-code"><code><IfModule mod_rewrite.c>
+    # Executed only when mod_rewrite is available
+    RewriteEngine On
+    ...
+</IfModule></code></pre>
+
+						<h3><code>RewriteCond</code> — condition (if statement)</h3>
+						<p>Evaluates whether to run the following <code>RewriteRule</code>. Multiple consecutive conditions default to an <strong>AND relationship</strong> — all conditions must match for the rule to fire.</p>
+						<pre class="article-code"><code>RewriteCond %{TEST_STRING} pattern [flags]</code></pre>
+
+						<h3><code>RewriteRule</code> — the action</h3>
+						<p>Rewrites or redirects the URL when all preceding conditions are satisfied.</p>
+						<pre class="article-code"><code>RewriteRule pattern substitution [flags]</code></pre>
+
+						<blockquote>
+							<p>For a detailed breakdown of directives and flags, see the <a href="../directives-guide/">Directives &amp; Flags Guide</a>.</p>
+						</blockquote>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<!-- 注意事項 -->
 					<section>
+						<div class="lang-block" data-lang="ja">
 						<h2>注意事項</h2>
 
 						<h3>編集前に必ずバックアップを取る</h3>
@@ -356,15 +582,51 @@ RewriteRule . /index.php [L]
 						<h3>500 エラーが出たときのリカバリ</h3>
 						<p>編集後に 500 エラーが発生したら、バックアップファイルを元の名前に戻せばサイトは復旧する。詳しいリカバリ手順は <a
 								href="../recovery-guide/">リカバリ方法ガイド</a> を参照。</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+						<h2>Important notes</h2>
+
+						<h3>Always back up before editing</h3>
+						<p>A typo in <code>.htaccess</code> will <strong>immediately trigger a 500 error (site outage)</strong>. Always download a backup before making any changes.</p>
+
+						<div class="table-wrap">
+							<table>
+								<thead>
+									<tr>
+										<th>Backup method</th>
+										<th>Steps</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>FTP / File manager</td>
+										<td>Download the existing <code>.htaccess</code> and save it locally</td>
+									</tr>
+									<tr>
+										<td>Rename a copy on the server</td>
+										<td>Duplicate and rename to <code>.htaccess.bak</code> on the server</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+
+						<h3>Recovery when a 500 error occurs</h3>
+						<p>If a 500 error appears after editing, restore the backup file to its original name and the site will recover. For detailed recovery steps, see the <a href="../recovery-guide/">Recovery Guide</a>.</p>
+						</div>
 					</section>
 
 					<!-- ジェネレーターへ戻る -->
 					<div class="article-back">
-						<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+						<div class="lang-block" data-lang="ja">
+							<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<a href="../" class="btn btn-secondary">← Back to Generator</a>
+						</div>
 					</div>
 
 					<aside class="license-notice">
-						<div>
+						<div class="lang-block" data-lang="ja">
 							<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja"
 								rel="nofollow noreferrer noopener" target="_blank">
 								<img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png"
@@ -377,6 +639,24 @@ RewriteRule . /index.php [L]
 								の下で提供されています。
 								<strong>有料オンライン講座・有料教材への転載は禁止</strong>しています。
 								詳細は<a href="/terms" rel="nofollow noreferrer">利用規約</a>をご確認ください。
+							</p>
+							<p>
+								&copy; 2026 まーちゅう（<a href="https://x.com/RocketMartue"
+									rel="nofollow noreferrer noopener" target="_blank">web-ya3.com</a>）
+							</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en"
+								rel="nofollow noreferrer noopener" target="_blank">
+								<img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png"
+									alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International" width="88" height="31">
+							</a>
+							<p>
+								This content is licensed under
+								<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en"
+									rel="nofollow noreferrer noopener" target="_blank">CC BY-NC-SA 4.0</a>.
+								<strong>Reproduction in paid online courses or paid educational materials is prohibited.</strong>
+								See the <a href="/terms" rel="nofollow noreferrer">Terms of Use</a> for details.
 							</p>
 							<p>
 								&copy; 2026 まーちゅう（<a href="https://x.com/RocketMartue"

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -53,7 +53,7 @@
 
 			<header class="app-header">
 				<h1><a href="../">.htaccess Generator</a><span class="h1-sub">for WordPress</span></h1>
-				<p>.htaccess とは？入門ガイド</p>
+				<p data-i18n="guide.htaccess-basics.subtitle">.htaccess とは？入門ガイド</p>
 				<div class="header-actions">
 					<button type="button" class="lang-toggle-btn" aria-label="言語切り替え（Switch to English）"
 						data-i18n-aria-label="guide.lang.btn.label">
@@ -244,7 +244,8 @@
 										<tr>
 											<td>File protection</td>
 											<td>Deny direct access to <code>wp-config.php</code> or
-												<code>.htaccess</code> itself</td>
+												<code>.htaccess</code> itself
+											</td>
 										</tr>
 										<tr>
 											<td>Response header injection</td>
@@ -368,7 +369,8 @@
 							<blockquote>
 								<p><strong>On Nginx:</strong> Configuration is done in <code>nginx.conf</code> or a
 									<code>server</code> block. The syntax differs, but the concepts overlap, so your
-									<code>.htaccess</code> knowledge still applies.</p>
+									<code>.htaccess</code> knowledge still applies.
+								</p>
 							</blockquote>
 						</div>
 					</section>
@@ -378,15 +380,15 @@
 					<!-- WordPress との関係 -->
 					<section>
 						<div class="lang-block" data-lang="ja">
-						<h2>WordPress との関係</h2>
+							<h2>WordPress との関係</h2>
 
-						<h3>WordPress が自動生成するブロック</h3>
-						<p>WordPress の「設定 → パーマリンク設定」を保存すると、<code>.htaccess</code> に以下のブロックが自動生成される。</p>
-						<pre class="article-code"><code># BEGIN WordPress
+							<h3>WordPress が自動生成するブロック</h3>
+							<p>WordPress の「設定 → パーマリンク設定」を保存すると、<code>.htaccess</code> に以下のブロックが自動生成される。</p>
+							<pre class="article-code"><code># BEGIN WordPress
 # "BEGIN WordPress" から "END WordPress" までのディレクティブ (行) は
 # 動的に生成され、WordPress フィルターによってのみ修正が可能です。
 # これらのマーカー間にあるディレクティブへの変更はすべて上書きされます。
-<IfModule mod_rewrite.c>
+&lt;IfModule mod_rewrite.c&gt;
 RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /
@@ -394,28 +396,29 @@ RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.php [L]
-</IfModule>
+&lt;/IfModule&gt;
 # END WordPress</code></pre>
-						<blockquote>
-							<p><strong>補足:</strong>
-								<code>RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]</code> は WordPress
-								6.0 以降で追加された行。Apache が <code>Authorization</code> ヘッダーを破棄する問題に対処するためのもので、REST API や
-								Application Passwords の動作に影響する。WordPress のバージョンによって自動生成されるブロックの内容が異なる場合がある。
-							</p>
-						</blockquote>
+							<blockquote>
+								<p><strong>補足:</strong>
+									<code>RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]</code> は
+									WordPress
+									6.0 以降で追加された行。Apache が <code>Authorization</code> ヘッダーを破棄する問題に対処するためのもので、REST API や
+									Application Passwords の動作に影響する。WordPress のバージョンによって自動生成されるブロックの内容が異なる場合がある。
+								</p>
+							</blockquote>
 
-						<h3>カスタムルールを書く場所</h3>
-						<p><code># BEGIN WordPress</code> 〜 <code># END WordPress</code> の間は <strong>WordPress
-								が自動的に上書き</strong>するため、直接編集してはいけない。カスタムルールはこのブロックの<strong>外（上）</strong>に追記する。</p>
-						<pre class="article-code"><code># ✅ ここにカスタムルールを書く（WordPress ブロックより上）
+							<h3>カスタムルールを書く場所</h3>
+							<p><code># BEGIN WordPress</code> 〜 <code># END WordPress</code> の間は <strong>WordPress
+									が自動的に上書き</strong>するため、直接編集してはいけない。カスタムルールはこのブロックの<strong>外（上）</strong>に追記する。</p>
+							<pre class="article-code"><code># ✅ ここにカスタムルールを書く（WordPress ブロックより上）
 
 # 例: HTTPS リダイレクト
-<IfModule mod_rewrite.c>
+&lt;IfModule mod_rewrite.c&gt;
     RewriteEngine On
     RewriteCond %{HTTPS} !=on [NC]
     RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
     RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-</IfModule>
+&lt;/IfModule&gt;
 
 # ⚠️ プラグインが生成するブロックも触らない（Wordfence、EWWW 等）
 # ...
@@ -425,23 +428,25 @@ RewriteRule . /index.php [L]
 ...
 # END WordPress</code></pre>
 
-						<blockquote>
-							<p>ルールの書き順は「カスタムルール → プラグイン生成ブロック →
-								<code># BEGIN WordPress</code>」が一般的。プラグインが生成するブロック（Wordfence・EWWW Image Optimizer・Nginx
-								Cache 等）も WordPress ブロックと同様に直接編集しない。
-							</p>
-						</blockquote>
+							<blockquote>
+								<p>ルールの書き順は「カスタムルール → プラグイン生成ブロック →
+									<code># BEGIN WordPress</code>」が一般的。プラグインが生成するブロック（Wordfence・EWWW Image
+									Optimizer・Nginx
+									Cache 等）も WordPress ブロックと同様に直接編集しない。
+								</p>
+							</blockquote>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
-						<h2>Relationship with WordPress</h2>
+							<h2>Relationship with WordPress</h2>
 
-						<h3>The block WordPress auto-generates</h3>
-						<p>When you save settings under <strong>Settings → Permalinks</strong> in WordPress, the following block is automatically written to <code>.htaccess</code>.</p>
-						<pre class="article-code"><code># BEGIN WordPress
+							<h3>The block WordPress auto-generates</h3>
+							<p>When you save settings under <strong>Settings → Permalinks</strong> in WordPress, the
+								following block is automatically written to <code>.htaccess</code>.</p>
+							<pre class="article-code"><code># BEGIN WordPress
 # The directives (lines) between "BEGIN WordPress" and "END WordPress"
 # are dynamically generated, and should only be modified via WordPress filters.
 # Any changes to the directives between these markers will be overwritten.
-<IfModule mod_rewrite.c>
+&lt;IfModule mod_rewrite.c&gt;
 RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /
@@ -449,25 +454,32 @@ RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.php [L]
-</IfModule>
+&lt;/IfModule&gt;
 # END WordPress</code></pre>
-						<blockquote>
-							<p><strong>Note:</strong>
-								The line <code>RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]</code> was added in WordPress 6.0 to fix a bug where Apache strips the <code>Authorization</code> header, which affects the REST API and Application Passwords. The exact content of the auto-generated block may vary between WordPress versions.
-							</p>
-						</blockquote>
+							<blockquote>
+								<p><strong>Note:</strong>
+									The line <code>RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]</code>
+									was added in WordPress 6.0 to fix a bug where Apache strips the
+									<code>Authorization</code> header, which affects the REST API and Application
+									Passwords. The exact content of the auto-generated block may vary between WordPress
+									versions.
+								</p>
+							</blockquote>
 
-						<h3>Where to put your custom rules</h3>
-						<p>Everything between <code># BEGIN WordPress</code> and <code># END WordPress</code> is <strong>automatically overwritten by WordPress</strong> — never edit it directly. Add your custom rules <strong>above</strong> the block.</p>
-						<pre class="article-code"><code># ✅ Write your custom rules here (above the WordPress block)
+							<h3>Where to put your custom rules</h3>
+							<p>Everything between <code># BEGIN WordPress</code> and <code># END WordPress</code> is
+								<strong>automatically overwritten by WordPress</strong> — never edit it directly. Add
+								your custom rules <strong>above</strong> the block.
+							</p>
+							<pre class="article-code"><code># ✅ Write your custom rules here (above the WordPress block)
 
 # Example: HTTPS redirect
-<IfModule mod_rewrite.c>
+&lt;IfModule mod_rewrite.c&gt;
     RewriteEngine On
     RewriteCond %{HTTPS} !=on [NC]
     RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
     RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-</IfModule>
+&lt;/IfModule&gt;
 
 # ⚠️ Also leave plugin-generated blocks untouched (Wordfence, EWWW, etc.)
 # ...
@@ -476,9 +488,12 @@ RewriteRule . /index.php [L]
 # (Auto-generated by WordPress — do not edit)
 ...
 # END WordPress</code></pre>
-						<blockquote>
-							<p>The typical order is: custom rules → plugin-generated blocks → <code># BEGIN WordPress</code>. Treat plugin-generated blocks (Wordfence, EWWW Image Optimizer, Nginx Cache, etc.) the same way — never edit them directly.</p>
-						</blockquote>
+							<blockquote>
+								<p>The typical order is: custom rules → plugin-generated blocks →
+									<code># BEGIN WordPress</code>. Treat plugin-generated blocks (Wordfence, EWWW Image
+									Optimizer, Nginx Cache, etc.) the same way — never edit them directly.
+								</p>
+							</blockquote>
 						</div>
 					</section>
 
@@ -487,63 +502,71 @@ RewriteRule . /index.php [L]
 					<!-- 基本構文の3つの柱 -->
 					<section>
 						<div class="lang-block" data-lang="ja">
-						<h2>基本構文の 3 つの柱</h2>
-						<p><code>.htaccess</code> に登場するコードのほとんどは、次の 3 つのディレクティブの組み合わせで成り立っている。</p>
+							<h2>基本構文の 3 つの柱</h2>
+							<p><code>.htaccess</code> に登場するコードのほとんどは、次の 3 つのディレクティブの組み合わせで成り立っている。</p>
 
-						<pre class="article-code"><code>IfModule      → 「このモジュールは使える？」（安全装置）
+							<pre class="article-code"><code>IfModule      → 「このモジュールは使える？」（安全装置）
  └ RewriteCond  → 「この条件に合致する？」（if 文）
    └ RewriteRule  → 「条件を満たしたのでこう処理する」（実行）</code></pre>
 
-						<h3><code>&lt;IfModule&gt;</code> — モジュールの安全装置</h3>
-						<p>指定した Apache モジュールが有効な場合にのみ、中のディレクティブを実行する。モジュールが存在しない環境で <code>&lt;IfModule&gt;</code> なしに書くと
-							<strong>500 エラーでサイトダウン</strong>になるため、必ず囲む。
-						</p>
-						<pre class="article-code"><code><IfModule mod_rewrite.c>
+							<h3><code>&lt;IfModule&gt;</code> — モジュールの安全装置</h3>
+							<p>指定した Apache モジュールが有効な場合にのみ、中のディレクティブを実行する。モジュールが存在しない環境で <code>&lt;IfModule&gt;</code>
+								なしに書くと
+								<strong>500 エラーでサイトダウン</strong>になるため、必ず囲む。
+							</p>
+							<pre class="article-code"><code>&lt;IfModule mod_rewrite.c&gt;
     # mod_rewrite が有効なときだけ実行される
     RewriteEngine On
     ...
-</IfModule></code></pre>
+&lt;/IfModule&gt;</code></pre>
 
-						<h3><code>RewriteCond</code> — 条件（if 文）</h3>
-						<p>直後の <code>RewriteRule</code> を実行するかどうかを判定する条件文。複数行並べるとデフォルトで <strong>AND
-								条件</strong>（すべて満たしたときだけ実行）。</p>
-						<pre class="article-code"><code>RewriteCond %{テスト文字列} パターン [フラグ]</code></pre>
+							<h3><code>RewriteCond</code> — 条件（if 文）</h3>
+							<p>直後の <code>RewriteRule</code> を実行するかどうかを判定する条件文。複数行並べるとデフォルトで <strong>AND
+									条件</strong>（すべて満たしたときだけ実行）。</p>
+							<pre class="article-code"><code>RewriteCond %{テスト文字列} パターン [フラグ]</code></pre>
 
-						<h3><code>RewriteRule</code> — 処理の実行</h3>
-						<p>条件を満たした場合に URL の書き換えやリダイレクトを実行する。</p>
-						<pre class="article-code"><code>RewriteRule パターン 置換先 [フラグ]</code></pre>
+							<h3><code>RewriteRule</code> — 処理の実行</h3>
+							<p>条件を満たした場合に URL の書き換えやリダイレクトを実行する。</p>
+							<pre class="article-code"><code>RewriteRule パターン 置換先 [フラグ]</code></pre>
 
-						<blockquote>
-							<p>ディレクティブとフラグの詳細は <a href="../directives-guide/">ディレクティブ・フラグ解説ガイド</a> で解説している。</p>
-						</blockquote>
+							<blockquote>
+								<p>ディレクティブとフラグの詳細は <a href="../directives-guide/">ディレクティブ・フラグ解説ガイド</a> で解説している。</p>
+							</blockquote>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
-						<h2>The three pillars of .htaccess syntax</h2>
-						<p>Most of the code you encounter in <code>.htaccess</code> is built from combinations of these three directives.</p>
+							<h2>The three pillars of .htaccess syntax</h2>
+							<p>Most of the code you encounter in <code>.htaccess</code> is built from combinations of
+								these three directives.</p>
 
-						<pre class="article-code"><code>IfModule      → "Is this module available?" (safety guard)
+							<pre class="article-code"><code>IfModule      → "Is this module available?" (safety guard)
  └ RewriteCond  → "Does this condition match?" (if statement)
    └ RewriteRule  → "Condition met — apply this transformation" (action)</code></pre>
 
-						<h3><code>&lt;IfModule&gt;</code> — safety guard for modules</h3>
-						<p>Executes the enclosed directives only when the specified Apache module is enabled. Writing module-dependent directives without <code>&lt;IfModule&gt;</code> on a server that lacks the module will cause a <strong>500 error and site outage</strong>, so always wrap them.</p>
-						<pre class="article-code"><code><IfModule mod_rewrite.c>
+							<h3><code>&lt;IfModule&gt;</code> — safety guard for modules</h3>
+							<p>Executes the enclosed directives only when the specified Apache module is enabled.
+								Writing module-dependent directives without <code>&lt;IfModule&gt;</code> on a server
+								that lacks the module will cause a <strong>500 error and site outage</strong>, so always
+								wrap them.</p>
+							<pre class="article-code"><code>&lt;IfModule mod_rewrite.c&gt;
     # Executed only when mod_rewrite is available
     RewriteEngine On
     ...
-</IfModule></code></pre>
+&lt;/IfModule&gt;</code></pre>
 
-						<h3><code>RewriteCond</code> — condition (if statement)</h3>
-						<p>Evaluates whether to run the following <code>RewriteRule</code>. Multiple consecutive conditions default to an <strong>AND relationship</strong> — all conditions must match for the rule to fire.</p>
-						<pre class="article-code"><code>RewriteCond %{TEST_STRING} pattern [flags]</code></pre>
+							<h3><code>RewriteCond</code> — condition (if statement)</h3>
+							<p>Evaluates whether to run the following <code>RewriteRule</code>. Multiple consecutive
+								conditions default to an <strong>AND relationship</strong> — all conditions must match
+								for the rule to fire.</p>
+							<pre class="article-code"><code>RewriteCond %{TEST_STRING} pattern [flags]</code></pre>
 
-						<h3><code>RewriteRule</code> — the action</h3>
-						<p>Rewrites or redirects the URL when all preceding conditions are satisfied.</p>
-						<pre class="article-code"><code>RewriteRule pattern substitution [flags]</code></pre>
+							<h3><code>RewriteRule</code> — the action</h3>
+							<p>Rewrites or redirects the URL when all preceding conditions are satisfied.</p>
+							<pre class="article-code"><code>RewriteRule pattern substitution [flags]</code></pre>
 
-						<blockquote>
-							<p>For a detailed breakdown of directives and flags, see the <a href="../directives-guide/">Directives &amp; Flags Guide</a>.</p>
-						</blockquote>
+							<blockquote>
+								<p>For a detailed breakdown of directives and flags, see the <a
+										href="../directives-guide/">Directives &amp; Flags Guide</a>.</p>
+							</blockquote>
 						</div>
 					</section>
 
@@ -552,66 +575,69 @@ RewriteRule . /index.php [L]
 					<!-- 注意事項 -->
 					<section>
 						<div class="lang-block" data-lang="ja">
-						<h2>注意事項</h2>
+							<h2>注意事項</h2>
 
-						<h3>編集前に必ずバックアップを取る</h3>
-						<p><code>.htaccess</code> の記述ミスは <strong>即座に 500 エラー（サイトダウン）</strong>
-							につながる。編集前にかならずバックアップを取っておくこと。</p>
+							<h3>編集前に必ずバックアップを取る</h3>
+							<p><code>.htaccess</code> の記述ミスは <strong>即座に 500 エラー（サイトダウン）</strong>
+								につながる。編集前にかならずバックアップを取っておくこと。</p>
 
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>バックアップ方法</th>
-										<th>手順</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>FTP / ファイルマネージャー</td>
-										<td>既存の <code>.htaccess</code> をダウンロードしてローカルに保存</td>
-									</tr>
-									<tr>
-										<td>ファイル名を変えてコピー</td>
-										<td>サーバー上で <code>.htaccess.bak</code> などにリネームコピー</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>バックアップ方法</th>
+											<th>手順</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>FTP / ファイルマネージャー</td>
+											<td>既存の <code>.htaccess</code> をダウンロードしてローカルに保存</td>
+										</tr>
+										<tr>
+											<td>ファイル名を変えてコピー</td>
+											<td>サーバー上で <code>.htaccess.bak</code> などにリネームコピー</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 
-						<h3>500 エラーが出たときのリカバリ</h3>
-						<p>編集後に 500 エラーが発生したら、バックアップファイルを元の名前に戻せばサイトは復旧する。詳しいリカバリ手順は <a
-								href="../recovery-guide/">リカバリ方法ガイド</a> を参照。</p>
+							<h3>500 エラーが出たときのリカバリ</h3>
+							<p>編集後に 500 エラーが発生したら、バックアップファイルを元の名前に戻せばサイトは復旧する。詳しいリカバリ手順は <a
+									href="../recovery-guide/">リカバリ方法ガイド</a> を参照。</p>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
-						<h2>Important notes</h2>
+							<h2>Important notes</h2>
 
-						<h3>Always back up before editing</h3>
-						<p>A typo in <code>.htaccess</code> will <strong>immediately trigger a 500 error (site outage)</strong>. Always download a backup before making any changes.</p>
+							<h3>Always back up before editing</h3>
+							<p>A typo in <code>.htaccess</code> will <strong>immediately trigger a 500 error (site
+									outage)</strong>. Always download a backup before making any changes.</p>
 
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>Backup method</th>
-										<th>Steps</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>FTP / File manager</td>
-										<td>Download the existing <code>.htaccess</code> and save it locally</td>
-									</tr>
-									<tr>
-										<td>Rename a copy on the server</td>
-										<td>Duplicate and rename to <code>.htaccess.bak</code> on the server</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Backup method</th>
+											<th>Steps</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>FTP / File manager</td>
+											<td>Download the existing <code>.htaccess</code> and save it locally</td>
+										</tr>
+										<tr>
+											<td>Rename a copy on the server</td>
+											<td>Duplicate and rename to <code>.htaccess.bak</code> on the server</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 
-						<h3>Recovery when a 500 error occurs</h3>
-						<p>If a 500 error appears after editing, restore the backup file to its original name and the site will recover. For detailed recovery steps, see the <a href="../recovery-guide/">Recovery Guide</a>.</p>
+							<h3>Recovery when a 500 error occurs</h3>
+							<p>If a 500 error appears after editing, restore the backup file to its original name and
+								the site will recover. For detailed recovery steps, see the <a
+									href="../recovery-guide/">Recovery Guide</a>.</p>
 						</div>
 					</section>
 
@@ -649,13 +675,15 @@ RewriteRule . /index.php [L]
 							<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en"
 								rel="nofollow noreferrer noopener" target="_blank">
 								<img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png"
-									alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International" width="88" height="31">
+									alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+									width="88" height="31">
 							</a>
 							<p>
 								This content is licensed under
 								<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en"
 									rel="nofollow noreferrer noopener" target="_blank">CC BY-NC-SA 4.0</a>.
-								<strong>Reproduction in paid online courses or paid educational materials is prohibited.</strong>
+								<strong>Reproduction in paid online courses or paid educational materials is
+									prohibited.</strong>
 								See the <a href="/terms" rel="nofollow noreferrer">Terms of Use</a> for details.
 							</p>
 							<p>

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -15,8 +15,9 @@
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
-		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/">
-		<meta property="og:locale" content="ja_JP">
+		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/"
+			data-i18n-content="guide.htaccess-basics.ogUrl">
+		<meta property="og:locale" content="ja_JP" data-i18n-content="guide.htaccess-basics.ogLocale">
 		<meta property="og:site_name" content=".htaccess Generator">
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image">

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -4,11 +4,13 @@
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta name="description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+		<meta name="description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド"
+			data-i18n-content="guide.htaccess-basics.description">
 		<!-- OGP -->
 		<meta property="og:type" content="article">
-		<meta property="og:title" content=".htaccess とは？入門ガイド">
-		<meta property="og:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+		<meta property="og:title" content=".htaccess とは？入門ガイド" data-i18n-content="guide.htaccess-basics.title">
+		<meta property="og:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド"
+			data-i18n-content="guide.htaccess-basics.description">
 		<meta property="og:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta property="og:image:width" content="1200">
@@ -18,8 +20,9 @@
 		<meta property="og:site_name" content=".htaccess Generator">
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image">
-		<meta name="twitter:title" content=".htaccess とは？入門ガイド">
-		<meta name="twitter:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド">
+		<meta name="twitter:title" content=".htaccess とは？入門ガイド" data-i18n-content="guide.htaccess-basics.title">
+		<meta name="twitter:description" content=".htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド"
+			data-i18n-content="guide.htaccess-basics.description">
 		<meta name="twitter:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta name="license" content="https://creativecommons.org/licenses/by-nc-sa/4.0/">
@@ -30,7 +33,7 @@
 			href="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/?lang=en">
 		<link rel="alternate" hreflang="x-default"
 			href="https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/">
-		<title>.htaccess とは？入門ガイド | .htaccess Generator</title>
+		<title data-i18n="guide.htaccess-basics.title">.htaccess とは？入門ガイド | .htaccess Generator</title>
 		<script>
 			try {
 				if (window.localStorage && localStorage.getItem('htaccess-theme') === 'dark') {
@@ -56,9 +59,9 @@
 				<p data-i18n="guide.htaccess-basics.subtitle">.htaccess とは？入門ガイド</p>
 				<div class="header-actions">
 					<button type="button" class="lang-toggle-btn" aria-label="言語切り替え（Switch to English）"
-						data-i18n-aria-label="guide.lang.btn.label">
+						data-i18n-aria-label="lang.btn.label">
 						<span class="lang-toggle-icon" aria-hidden="true">🌐</span>
-						<span class="lang-toggle-label" data-i18n="guide.lang.btn.text">EN</span>
+						<span class="lang-toggle-label" data-i18n="lang.btn.text">EN</span>
 					</button>
 					<button type="button" class="theme-toggle-btn" aria-label="ダークモードに切り替え" aria-pressed="false">
 						<span class="theme-toggle-icon" aria-hidden="true">🌙</span>


### PR DESCRIPTION
## 概要

Issue #78 対応。ガイドページの多言語化（日本語 / 英語）を `htaccess-basics-guide` で先行実装し、パターンを確立する。

---

## 変更内容

### アプローチ：デュアル言語ブロック方式

各 `<section>` の中身を `data-lang` 付きの `.lang-block` で囲み、JS でトグルする。

```html
<div class="lang-block" data-lang="ja">日本語コンテンツ</div>
<div class="lang-block" data-lang="en" hidden>English content</div>
```

- JS 無効時：`hidden` 属性により日本語が表示（フォールバック正常動作）
- `?lang=en` URL パラメータで直接英語表示
- `localStorage` で言語設定を永続化

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `assets/js/locales/en.js` | `guide.htaccess-basics.subtitle` / `.title` / `.description` キー追加（`guide.lang.btn.*` は削除し `lang.btn.*` に統一） |
| `assets/js/locales/ja.js` | 同上（日本語値） |
| `assets/js/guide.js` | i18n 統合・async IIFE 化・`applyLangBlocks()` 追加（表示ブロックへの `lang` 属性付与含む）・lang toggle ハンドラ追加・ハンバーガー aria-label を `t()` 化・`DARK_THEME` 定数を `theme.js` から import して使用 |
| `assets/js/i18n.js` | `applyTranslations()` に `data-i18n-content` サポート追加（`<meta content>` 更新用） |
| `assets/scss/_article.scss` | `.lang-block[hidden] { display: none; }` 追加 |
| `assets/css/style.css` | SCSS コンパイル出力 |
| `htaccess-basics-guide/index.html` | hreflang タグ追加・lang toggle ボタン追加・全5 section を lang-block 構造化・英語コンテンツ追加・CC ライセンスリンクを `deed.en` / `deed.ja` に分岐・`<title>` / meta description / OGP / Twitter Card に `data-i18n` / `data-i18n-content` 属性付与 |

---

## 動作確認チェックリスト

- [ ] 言語トグルボタンをクリック → 全コンテンツが英語に切り替わる
- [ ] `?lang=en` URL パラメータで直接英語表示になる
- [ ] ページリロード後も選択言語が維持される（localStorage）
- [ ] テーマ切り替えが言語切り替え後も正常動作する
- [ ] ハンバーガーメニューの aria-label が言語に合わせて変わる
- [ ] `<title>` / meta description / OGP が言語に合わせて更新される
- [ ] JavaScript 無効時：日本語コンテンツが表示される（英語ブロックは hidden のまま）

---

## 残り 6 ページへの展開

確立したパターンを別 Issue で適用:

1. `recovery-guide`
2. `wp-protection-guide`
3. `options-errordocument-guide`
4. `cache-performance-guide`
5. `directives-guide`
6. `security-headers-guide`

Closes #78