### PR TITLE
fix: 入力バリデーション強化

### DIFF
--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -60,7 +60,7 @@ const isValidHtpasswdPath = (path) => {
 const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/;
 const IPV4_CIDR_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\/(?:[0-9]|[12]\d|3[0-2])$/;
 
-const isValidIpV4OrCidr = (value) => {
+const isValidIpv4OrCidr = (value) => {
 	if (typeof value !== 'string') return false;
 	const trimmed = value.trim();
 	return IPV4_RE.test(trimmed) || IPV4_CIDR_RE.test(trimmed);
@@ -207,9 +207,10 @@ const buildFileProtectionSection = (fileProtection, apacheVersion, t) => {
 
 	// wp-login.php Basic 認証
 	if (fileProtection.wpLoginBasicAuth && isValidHtpasswdPath(fileProtection.htpasswdPath)) {
+		const htpasswdPath = fileProtection.htpasswdPath.trim();
 		lines.push(t('gen.comment.wpLoginBasicAuth'));
 		lines.push('<Files wp-login.php>');
-		lines.push(`\tAuthUserFile "${fileProtection.htpasswdPath}"`);
+		lines.push(`\tAuthUserFile "${htpasswdPath}"`);
 		lines.push('\tAuthName "Member Site"');
 		lines.push('\tAuthType BASIC');
 		lines.push('\trequire valid-user');
@@ -231,7 +232,7 @@ const buildIpBlockSection = (ipBlock, t) => {
 		return [];
 	}
 
-	const ips = ipBlock.list.split('\n').map((s) => s.trim()).filter((s) => isValidIpV4OrCidr(s));
+	const ips = ipBlock.list.split('\n').map((s) => s.trim()).filter((s) => isValidIpv4OrCidr(s));
 	if (ips.length === 0) {
 		return [];
 	}
@@ -745,9 +746,10 @@ export const buildWpAdmin = (settings, t = (key) => key) => {
 		return [];
 	}
 
+	const htpasswdPath = admin.htpasswdPath.trim();
 	const lines = [];
 	lines.push(t('gen.comment.wpAdminBasicAuth'));
-	lines.push(`AuthUserFile "${admin.htpasswdPath}"`);
+	lines.push(`AuthUserFile "${htpasswdPath}"`);
 	lines.push('AuthName "Member Site"');
 	lines.push('AuthType BASIC');
 	lines.push('require valid-user');
@@ -775,25 +777,26 @@ export const buildWpAdmin = (settings, t = (key) => key) => {
 	}
 
 	// upgrade.php のサーバー内部 IP 除外
-	if (admin.upgradeIpExclude && isValidIpV4OrCidr(admin.serverIp)) {
+	if (admin.upgradeIpExclude && isValidIpv4OrCidr(admin.serverIp)) {
+		const serverIp = admin.serverIp.trim();
 		lines.push('');
 		lines.push(t('gen.comment.upgradeIpExclude'));
 		lines.push('<Files upgrade.php>');
 		if (apacheVersion === '2.4') {
 			lines.push('\t<RequireAny>');
-			lines.push(`\t\tRequire ip ${admin.serverIp}`);
+			lines.push(`\t\tRequire ip ${serverIp}`);
 			lines.push('\t\tRequire valid-user');
 			lines.push('\t</RequireAny>');
 		} else {
 			lines.push('\t<IfModule mod_authz_core.c>');
 			lines.push('\t\t<RequireAny>');
-			lines.push(`\t\t\tRequire ip ${admin.serverIp}`);
+			lines.push(`\t\t\tRequire ip ${serverIp}`);
 			lines.push('\t\t\tRequire valid-user');
 			lines.push('\t\t</RequireAny>');
 			lines.push('\t</IfModule>');
 			lines.push('\t<IfModule !mod_authz_core.c>');
 			lines.push('\t\tOrder deny,allow');
-			lines.push(`\t\tAllow from ${admin.serverIp}`);
+			lines.push(`\t\tAllow from ${serverIp}`);
 			lines.push('\t\tSatisfy any');
 			lines.push('\t</IfModule>');
 		}
@@ -824,4 +827,4 @@ export const buildUploads = (settings, t = (key) => key) => {
 	];
 };
 
-export { isValidHtpasswdPath, isValidIpV4OrCidr };
+export { isValidHtpasswdPath, isValidIpv4OrCidr };

--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -46,6 +46,31 @@ const VALID_EXPIRES_VALUES = ['1 hour', '1 day', '1 week', '1 month', '3 months'
 const VALID_CC_MAX_AGE_VALUES = ['3600', '86400', '604800', '2592000', '7776000', '31536000'];
 const VALID_HSTS_MAX_AGE_VALUES = ['300', '86400', '2592000', '31536000', '63072000'];
 
+// ─── 入力バリデーション ───────────────────────────────────────────
+
+const HTPASSWD_PATH_RE = /^\/[a-zA-Z0-9/_.\-]+$/;
+
+const isValidHtpasswdPath = (path) => {
+	if (typeof path !== 'string') return false;
+	const trimmed = path.trim();
+	if (trimmed.length === 0 || trimmed.length > 512) return false;
+	return HTPASSWD_PATH_RE.test(trimmed);
+};
+
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/;
+const IPV4_CIDR_RE = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\/(?:[0-9]|[12]\d|3[0-2])$/;
+
+const isValidIpV4OrCidr = (value) => {
+	if (typeof value !== 'string') return false;
+	const trimmed = value.trim();
+	return IPV4_RE.test(trimmed) || IPV4_CIDR_RE.test(trimmed);
+};
+
+const sanitizeCspValue = (v) => {
+	if (typeof v !== 'string') return '';
+	return v.replace(/[\x00-\x1f\x7f"\\]/g, '');
+};
+
 // ─── ヘルパー ─────────────────────────────────────────────────────
 
 /**
@@ -181,7 +206,7 @@ const buildFileProtectionSection = (fileProtection, apacheVersion, t) => {
 	}
 
 	// wp-login.php Basic 認証
-	if (fileProtection.wpLoginBasicAuth && fileProtection.htpasswdPath) {
+	if (fileProtection.wpLoginBasicAuth && isValidHtpasswdPath(fileProtection.htpasswdPath)) {
 		lines.push(t('gen.comment.wpLoginBasicAuth'));
 		lines.push('<Files wp-login.php>');
 		lines.push(`\tAuthUserFile "${fileProtection.htpasswdPath}"`);
@@ -206,7 +231,7 @@ const buildIpBlockSection = (ipBlock, t) => {
 		return [];
 	}
 
-	const ips = ipBlock.list.split('\n').map((s) => s.trim()).filter(Boolean);
+	const ips = ipBlock.list.split('\n').map((s) => s.trim()).filter((s) => isValidIpV4OrCidr(s));
 	if (ips.length === 0) {
 		return [];
 	}
@@ -478,7 +503,7 @@ const buildHeadersSection = (headers, t) => {
 		// Report-Only モードでは upgrade-insecure-requests は無視されるため除外する
 		const cspParts = headers.cspReportOnly ? [] : ['upgrade-insecure-requests'];
 
-		const sanitize = (v) => v.replace(/"/g, '');
+		const sanitize = sanitizeCspValue;
 
 		const buildSrc = (enabled, value, extras = []) => {
 			if (!enabled) return null;
@@ -716,7 +741,7 @@ export const buildWpAdmin = (settings, t = (key) => key) => {
 	const admin = settings.wpAdmin;
 	const apacheVersion = settings.apacheVersion ?? 'both';
 
-	if (!admin.basicAuth || !admin.htpasswdPath) {
+	if (!admin.basicAuth || !isValidHtpasswdPath(admin.htpasswdPath)) {
 		return [];
 	}
 
@@ -750,7 +775,7 @@ export const buildWpAdmin = (settings, t = (key) => key) => {
 	}
 
 	// upgrade.php のサーバー内部 IP 除外
-	if (admin.upgradeIpExclude && admin.serverIp) {
+	if (admin.upgradeIpExclude && isValidIpV4OrCidr(admin.serverIp)) {
 		lines.push('');
 		lines.push(t('gen.comment.upgradeIpExclude'));
 		lines.push('<Files upgrade.php>');
@@ -798,3 +823,5 @@ export const buildUploads = (settings, t = (key) => key) => {
 		'</FilesMatch>',
 	];
 };
+
+export { isValidHtpasswdPath, isValidIpV4OrCidr };

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -54,6 +54,7 @@ export default {
 	'toggle.wpLoginBasicAuth': 'Basic Auth for wp-login.php',
 	'input.htpasswdPath': 'Full path to .htpasswd',
 	'hint.htpasswdPath': 'Enter the full path to .htpasswd to apply',
+	'hint.htpasswdPathInvalid': 'Enter a valid full path to .htpasswd (e.g. /home/username/.htpasswd)',
 
 	// IP Block
 	'toggle.ipBlock': 'Block by IP address',
@@ -151,6 +152,7 @@ export default {
 	'toggle.wpAdminBasicAuth': 'Basic Auth for admin panel',
 	'input.adminHtpasswdPath': 'Full path to .htpasswd',
 	'hint.adminHtpasswdPath': 'Enter the full path to .htpasswd to apply',
+	'hint.adminHtpasswdPathInvalid': 'Enter a valid full path to .htpasswd (e.g. /home/username/.htpasswd)',
 	'toggle.ajaxExclude': 'Exclude admin-ajax.php',
 	'toggle.upgradeIpExclude': 'Exclude upgrade.php for server internal IP',
 	'input.serverIp': 'Server internal IP',

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -54,6 +54,7 @@ export default {
 	'toggle.wpLoginBasicAuth': 'wp-login.php に Basic 認証',
 	'input.htpasswdPath': '.htpasswd のフルパス',
 	'hint.htpasswdPath': '.htpasswd のフルパスを入力すると反映されます',
+	'hint.htpasswdPathInvalid': '.htpasswd のフルパスを正しい形式で入力してください（例: /home/username/.htpasswd）',
 
 	// IP ブロック
 	'toggle.ipBlock': 'IP アドレスによるブロック',
@@ -151,6 +152,7 @@ export default {
 	'toggle.wpAdminBasicAuth': '管理画面に Basic 認証',
 	'input.adminHtpasswdPath': '.htpasswd のフルパス',
 	'hint.adminHtpasswdPath': '.htpasswd のフルパスを入力すると反映されます',
+	'hint.adminHtpasswdPathInvalid': '.htpasswd のフルパスを正しい形式で入力してください（例: /home/username/.htpasswd）',
 	'toggle.ajaxExclude': 'admin-ajax.php を除外',
 	'toggle.upgradeIpExclude': 'upgrade.php のサーバー内部 IP 除外',
 	'input.serverIp': 'サーバー内部 IP',

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,7 +5,7 @@
  * プレビュー更新・コピー・ダウンロード処理を担う。
  */
 
-import { buildRoot, buildWpAdmin, buildUploads } from './generator.js';
+import { buildRoot, buildWpAdmin, buildUploads, isValidHtpasswdPath, isValidIpV4OrCidr } from './generator.js';
 import { PRESETS, DEFAULT_SETTINGS } from './presets.js';
 import { applyTheme, initTheme, setupThemeToggle, DARK_THEME } from './theme.js';
 import { t, getLang, setLang, initLang } from './i18n.js';
@@ -544,7 +544,7 @@ const updateConditionalFields = () => {
 		elLoginAuthFields.hidden = !elWpLoginBasicAuth?.checked;
 	}
 	if (elLoginHtpasswdHint) {
-		elLoginHtpasswdHint.hidden = !(elWpLoginBasicAuth?.checked && !elLoginHtpasswdPath?.value?.trim());
+		elLoginHtpasswdHint.hidden = !(elWpLoginBasicAuth?.checked && !isValidHtpasswdPath(elLoginHtpasswdPath?.value ?? ''));
 	}
 
 	// IP ブロックフィールド
@@ -608,7 +608,7 @@ const updateConditionalFields = () => {
 		elWpAdminFields.hidden = !elWpAdminBasicAuth?.checked;
 	}
 	if (elAdminHtpasswdHint) {
-		elAdminHtpasswdHint.hidden = !(elWpAdminBasicAuth?.checked && !elAdminHtpasswdPath?.value?.trim());
+		elAdminHtpasswdHint.hidden = !(elWpAdminBasicAuth?.checked && !isValidHtpasswdPath(elAdminHtpasswdPath?.value ?? ''));
 	}
 
 	// HSTS サブオプション

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,7 +5,7 @@
  * プレビュー更新・コピー・ダウンロード処理を担う。
  */
 
-import { buildRoot, buildWpAdmin, buildUploads, isValidHtpasswdPath, isValidIpV4OrCidr } from './generator.js';
+import { buildRoot, buildWpAdmin, buildUploads, isValidHtpasswdPath } from './generator.js';
 import { PRESETS, DEFAULT_SETTINGS } from './presets.js';
 import { applyTheme, initTheme, setupThemeToggle, DARK_THEME } from './theme.js';
 import { t, getLang, setLang, initLang } from './i18n.js';
@@ -544,7 +544,14 @@ const updateConditionalFields = () => {
 		elLoginAuthFields.hidden = !elWpLoginBasicAuth?.checked;
 	}
 	if (elLoginHtpasswdHint) {
-		elLoginHtpasswdHint.hidden = !(elWpLoginBasicAuth?.checked && !isValidHtpasswdPath(elLoginHtpasswdPath?.value ?? ''));
+		const loginPath = elLoginHtpasswdPath?.value ?? '';
+		const loginPathInvalid = elWpLoginBasicAuth?.checked && !isValidHtpasswdPath(loginPath);
+		elLoginHtpasswdHint.hidden = !loginPathInvalid;
+		if (loginPathInvalid) {
+			elLoginHtpasswdHint.textContent = loginPath.trim() === ''
+				? t('hint.htpasswdPath')
+				: t('hint.htpasswdPathInvalid');
+		}
 	}
 
 	// IP ブロックフィールド
@@ -608,7 +615,14 @@ const updateConditionalFields = () => {
 		elWpAdminFields.hidden = !elWpAdminBasicAuth?.checked;
 	}
 	if (elAdminHtpasswdHint) {
-		elAdminHtpasswdHint.hidden = !(elWpAdminBasicAuth?.checked && !isValidHtpasswdPath(elAdminHtpasswdPath?.value ?? ''));
+		const adminPath = elAdminHtpasswdPath?.value ?? '';
+		const adminPathInvalid = elWpAdminBasicAuth?.checked && !isValidHtpasswdPath(adminPath);
+		elAdminHtpasswdHint.hidden = !adminPathInvalid;
+		if (adminPathInvalid) {
+			elAdminHtpasswdHint.textContent = adminPath.trim() === ''
+				? t('hint.adminHtpasswdPath')
+				: t('hint.adminHtpasswdPathInvalid');
+		}
 	}
 
 	// HSTS サブオプション


### PR DESCRIPTION
## Summary

- `.htpasswd` パス入力に正規表現バリデーションを追加（ダブルクォート脱出を防止）
- IP アドレス / CIDR 入力に IPv4 形式の厳密な検証を追加
- CSP 値のサニタイズを強化（改行・制御文字・バックスラッシュも除去）
- `main.js` のヒント表示ロジックをバリデーション関数と統一

closes #86

## Test plan

- [ ] htpasswdPath に `"` や改行を含む値を入力 → Basic Auth ブロックが生成されないことを確認
- [ ] htpasswdPath に正常パス (`/home/user/.htpasswd`) → 正常に生成されることを確認
- [ ] IP ブロックリストに `not-an-ip` や `1.2.3.4 # comment` を入力 → 無視されることを確認
- [ ] IP ブロックリストに正常 IP (`192.168.1.0/24`) → 正常に生成されることを確認
- [ ] CSP 値に改行やバックスラッシュを入力 → 除去されて出力されることを確認
- [ ] 全プリセットが正常に動作することを確認（既存機能のリグレッション）