### PR TITLE
feat: i18n recovery-guide (#79)

### DIFF
--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -244,4 +244,9 @@ export default {
 	'guide.htaccess-basics.description': 'A beginner\'s guide explaining what .htaccess is, what it can do, supported environments, its relationship with WordPress, and basic syntax.',
 	'guide.htaccess-basics.ogUrl': 'https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/?lang=en',
 	'guide.htaccess-basics.ogLocale': 'en_US',
+	'guide.recovery.subtitle': 'Recovery Guide',
+	'guide.recovery.title': 'Recovery Guide | .htaccess Generator',
+	'guide.recovery.description': 'A guide explaining FTP recovery procedures and troubleshooting when a .htaccess misconfiguration causes a 500 error.',
+	'guide.recovery.ogUrl': 'https://htaccess-generator-b46.pages.dev/recovery-guide/?lang=en',
+	'guide.recovery.ogLocale': 'en_US',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -244,4 +244,9 @@ export default {
 	'guide.htaccess-basics.description': '.htaccess とは何か、できること・使える環境・WordPress との関係・基本構文をわかりやすく解説した入門ガイド',
 	'guide.htaccess-basics.ogUrl': 'https://htaccess-generator-b46.pages.dev/htaccess-basics-guide/',
 	'guide.htaccess-basics.ogLocale': 'ja_JP',
+	'guide.recovery.subtitle': 'リカバリ方法解説ガイド',
+	'guide.recovery.title': 'リカバリ方法解説ガイド | .htaccess Generator',
+	'guide.recovery.description': '.htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド',
+	'guide.recovery.ogUrl': 'https://htaccess-generator-b46.pages.dev/recovery-guide/',
+	'guide.recovery.ogLocale': 'ja_JP',
 };

--- a/recovery-guide/index.html
+++ b/recovery-guide/index.html
@@ -4,28 +4,35 @@
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta name="description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド">
+		<meta name="description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド"
+			data-i18n-content="guide.recovery.description">
 		<!-- OGP -->
 		<meta property="og:type" content="article">
-		<meta property="og:title" content="リカバリ方法解説ガイド">
-		<meta property="og:description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド">
+		<meta property="og:title" content="リカバリ方法解説ガイド" data-i18n-content="guide.recovery.title">
+		<meta property="og:description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド"
+			data-i18n-content="guide.recovery.description">
 		<meta property="og:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
-		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/recovery-guide/">
-		<meta property="og:locale" content="ja_JP">
+		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/recovery-guide/"
+			data-i18n-content="guide.recovery.ogUrl">
+		<meta property="og:locale" content="ja_JP" data-i18n-content="guide.recovery.ogLocale">
 		<meta property="og:site_name" content=".htaccess Generator">
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image">
-		<meta name="twitter:title" content="リカバリ方法解説ガイド">
-		<meta name="twitter:description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド">
+		<meta name="twitter:title" content="リカバリ方法解説ガイド" data-i18n-content="guide.recovery.title">
+		<meta name="twitter:description" content=".htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド"
+			data-i18n-content="guide.recovery.description">
 		<meta name="twitter:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta name="license" content="https://creativecommons.org/licenses/by-nc-sa/4.0/">
 
 		<link rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-		<title>リカバリ方法解説ガイド | .htaccess Generator</title>
+		<link rel="alternate" hreflang="ja" href="https://htaccess-generator-b46.pages.dev/recovery-guide/">
+		<link rel="alternate" hreflang="en" href="https://htaccess-generator-b46.pages.dev/recovery-guide/?lang=en">
+		<link rel="alternate" hreflang="x-default" href="https://htaccess-generator-b46.pages.dev/recovery-guide/">
+		<title data-i18n="guide.recovery.title">リカバリ方法解説ガイド | .htaccess Generator</title>
 		<script>
 			try {
 				if (window.localStorage && localStorage.getItem('htaccess-theme') === 'dark') {
@@ -43,13 +50,18 @@
 	</head>
 
 	<body>
-		<a href="#main-content" class="skip-link">メインコンテンツへスキップ</a>
+		<a href="#main-content" class="skip-link" data-i18n="skip.link">メインコンテンツへスキップ</a>
 		<div class="app-wrapper">
 
 			<header class="app-header">
 				<h1><a href="../">.htaccess Generator</a><span class="h1-sub">for WordPress</span></h1>
-				<p>リカバリ方法解説ガイド</p>
+				<p data-i18n="guide.recovery.subtitle">リカバリ方法解説ガイド</p>
 				<div class="header-actions">
+					<button type="button" class="lang-toggle-btn" aria-label="言語切り替え（Switch to English）"
+						data-i18n-aria-label="lang.btn.label">
+						<span class="lang-toggle-icon" aria-hidden="true">🌐</span>
+						<span class="lang-toggle-label" data-i18n="lang.btn.text">EN</span>
+					</button>
 					<button type="button" class="theme-toggle-btn" aria-label="ダークモードに切り替え" aria-pressed="false">
 						<span class="theme-toggle-icon" aria-hidden="true">🌙</span>
 						<span class="theme-toggle-label">ダーク</span>
@@ -63,7 +75,7 @@
 				</div>
 			</header>
 
-			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション">
+			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション" data-i18n-aria-label="nav.aria">
 				<div class="site-nav-card">
 					<ul class="site-nav-list">
 						<li><a href="../"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14"
@@ -95,100 +107,212 @@
 
 					<!-- はじめに -->
 					<section>
-						<h2>設定を変える前に必ずバックアップ</h2>
+						<div class="lang-block" data-lang="ja">
+							<h2>設定を変える前に必ずバックアップ</h2>
 
-						<p><code>.htaccess</code> の記述ミスは <strong>500 Internal Server Error（サイトダウン）</strong>
-							に直結する。編集作業の前にかならずバックアップを取ること。</p>
+							<p><code>.htaccess</code> の記述ミスは <strong>500 Internal Server Error（サイトダウン）</strong>
+								に直結する。編集作業の前にかならずバックアップを取ること。</p>
 
-						<p>バックアップ方法の例:</p>
-						<ul>
-							<li>FTP クライアントで <code>.htaccess</code> をローカルにダウンロードして保存</li>
-							<li>サーバーのファイルマネージャーで別名コピーを作成（例: <code>.htaccess.bak</code>）</li>
-							<li>バックアッププラグイン（UpdraftPlus 等）でスナップショットを取得</li>
-						</ul>
+							<p>バックアップ方法の例:</p>
+							<ul>
+								<li>FTP クライアントで <code>.htaccess</code> をローカルにダウンロードして保存</li>
+								<li>サーバーのファイルマネージャーで別名コピーを作成（例: <code>.htaccess.bak</code>）</li>
+								<li>バックアッププラグイン（UpdraftPlus 等）でスナップショットを取得</li>
+							</ul>
 
-						<blockquote>
-							<p>たとえサイトが壊れても、バックアップがあれば数分で復旧できる。バックアップなしの編集は絶対に避ける。</p>
-						</blockquote>
+							<blockquote>
+								<p>たとえサイトが壊れても、バックアップがあれば数分で復旧できる。バックアップなしの編集は絶対に避ける。</p>
+							</blockquote>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>Back Up Before Making Changes</h2>
+
+							<p>A typo in <code>.htaccess</code> can directly cause a <strong>500 Internal Server Error
+									(site down)</strong>.
+								Always take a backup before editing.</p>
+
+							<p>Examples of backup methods:</p>
+							<ul>
+								<li>Download <code>.htaccess</code> to your local machine via an FTP client</li>
+								<li>Create a copy with a different name in the server's file manager (e.g.
+									<code>.htaccess.bak</code>)</li>
+								<li>Take a snapshot using a backup plugin (e.g. UpdraftPlus)</li>
+							</ul>
+
+							<blockquote>
+								<p>Even if your site breaks, a backup lets you recover in minutes. Never edit without a
+									backup.</p>
+							</blockquote>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<!-- FTP でのリカバリ手順 -->
 					<section>
-						<h2>FTP / ファイルマネージャーでのリカバリ手順</h2>
+						<div class="lang-block" data-lang="ja">
+							<h2>FTP / ファイルマネージャーでのリカバリ手順</h2>
 
-						<p>.htaccess の設定ミスでサイトが 500 エラーになった場合の緊急復旧手順。</p>
+							<p>.htaccess の設定ミスでサイトが 500 エラーになった場合の緊急復旧手順。</p>
 
-						<h3>手順</h3>
+							<h3>手順</h3>
 
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>ステップ</th>
-										<th>操作</th>
-										<th>ポイント</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>1</td>
-										<td>FTP クライアントまたはサーバーのファイルマネージャーに接続する</td>
-										<td>WordPress の管理画面にはアクセスできない状態のため、サーバーに直接接続する</td>
-									</tr>
-									<tr>
-										<td>2</td>
-										<td><code>public_html/</code>（または <code>www/</code>）にある <code>.htaccess</code>
-											をリネームする</td>
-										<td><code>.htaccess</code> → <code>_htaccess</code>
-											などに変更する。削除ではなくリネームすることで後で見直せる</td>
-									</tr>
-									<tr>
-										<td>3</td>
-										<td>サイトにアクセスして復旧を確認する</td>
-										<td>サイトが表示されれば <code>.htaccess</code> が原因と確定。WordPress のパーマリンクは一時的に崩れる場合がある</td>
-									</tr>
-									<tr>
-										<td>4</td>
-										<td>リネームした <code>_htaccess</code> を開いて問題のある記述を特定する</td>
-										<td>一行ずつコメントアウト（<code>#</code> を先頭に追加）して原因を特定する</td>
-									</tr>
-									<tr>
-										<td>5</td>
-										<td>修正が完了したらファイルを <code>.htaccess</code> に戻す</td>
-										<td>拡張子なしのファイル名に注意。FTP クライアントによっては隠しファイル（<code>.</code> で始まるファイル）の表示設定が必要</td>
-									</tr>
-								</tbody>
-							</table>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>ステップ</th>
+											<th>操作</th>
+											<th>ポイント</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>1</td>
+											<td>FTP クライアントまたはサーバーのファイルマネージャーに接続する</td>
+											<td>WordPress の管理画面にはアクセスできない状態のため、サーバーに直接接続する</td>
+										</tr>
+										<tr>
+											<td>2</td>
+											<td><code>public_html/</code>（または <code>www/</code>）にある
+												<code>.htaccess</code>
+												をリネームする</td>
+											<td><code>.htaccess</code> → <code>_htaccess</code>
+												などに変更する。削除ではなくリネームすることで後で見直せる</td>
+										</tr>
+										<tr>
+											<td>3</td>
+											<td>サイトにアクセスして復旧を確認する</td>
+											<td>サイトが表示されれば <code>.htaccess</code> が原因と確定。WordPress のパーマリンクは一時的に崩れる場合がある
+											</td>
+										</tr>
+										<tr>
+											<td>4</td>
+											<td>リネームした <code>_htaccess</code> を開いて問題のある記述を特定する</td>
+											<td>一行ずつコメントアウト（<code>#</code> を先頭に追加）して原因を特定する</td>
+										</tr>
+										<tr>
+											<td>5</td>
+											<td>修正が完了したらファイルを <code>.htaccess</code> に戻す</td>
+											<td>拡張子なしのファイル名に注意。FTP クライアントによっては隠しファイル（<code>.</code> で始まるファイル）の表示設定が必要
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+
+							<h3>FTP クライアントで隠しファイルを表示するには</h3>
+							<p><code>.htaccess</code> は先頭が <code>.</code> の隠しファイルのため、デフォルトで非表示になる FTP クライアントがある。</p>
+
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>クライアント</th>
+											<th>設定方法</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>FileZilla</td>
+											<td>「サーバー」メニュー →「隠しファイルを表示する」</td>
+										</tr>
+										<tr>
+											<td>Cyberduck</td>
+											<td>環境設定 →「ブラウザ」→「隠しファイルを表示する」</td>
+										</tr>
+										<tr>
+											<td>サーバーのファイルマネージャー</td>
+											<td>各ホスティングの管理パネルから「ファイルマネージャー」を開き、「隠しファイルを表示」オプションを有効にする</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>Recovery Steps via FTP / File Manager</h2>
 
-						<h3>FTP クライアントで隠しファイルを表示するには</h3>
-						<p><code>.htaccess</code> は先頭が <code>.</code> の隠しファイルのため、デフォルトで非表示になる FTP クライアントがある。</p>
+							<p>Emergency recovery procedure when a .htaccess misconfiguration causes a 500 error on your
+								site.</p>
 
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>クライアント</th>
-										<th>設定方法</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>FileZilla</td>
-										<td>「サーバー」メニュー →「隠しファイルを表示する」</td>
-									</tr>
-									<tr>
-										<td>Cyberduck</td>
-										<td>環境設定 →「ブラウザ」→「隠しファイルを表示する」</td>
-									</tr>
-									<tr>
-										<td>サーバーのファイルマネージャー</td>
-										<td>各ホスティングの管理パネルから「ファイルマネージャー」を開き、「隠しファイルを表示」オプションを有効にする</td>
-									</tr>
-								</tbody>
-							</table>
+							<h3>Steps</h3>
+
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Step</th>
+											<th>Action</th>
+											<th>Notes</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>1</td>
+											<td>Connect via an FTP client or the server's file manager</td>
+											<td>Since the WordPress admin panel is inaccessible, connect directly to the
+												server</td>
+										</tr>
+										<tr>
+											<td>2</td>
+											<td>Rename <code>.htaccess</code> inside <code>public_html/</code> (or
+												<code>www/</code>)</td>
+											<td>Rename to something like <code>_htaccess</code>. Renaming (not deleting)
+												lets you review it later</td>
+										</tr>
+										<tr>
+											<td>3</td>
+											<td>Visit your site and confirm it is back up</td>
+											<td>If the site loads, <code>.htaccess</code> was the cause. WordPress
+												permalinks may temporarily break</td>
+										</tr>
+										<tr>
+											<td>4</td>
+											<td>Open the renamed <code>_htaccess</code> and identify the problematic
+												entry</td>
+											<td>Comment out lines one by one (add <code>#</code> at the start) to
+												isolate the cause</td>
+										</tr>
+										<tr>
+											<td>5</td>
+											<td>Once fixed, rename the file back to <code>.htaccess</code></td>
+											<td>Note that the filename has no extension. Some FTP clients require a
+												setting to display hidden files (those starting with <code>.</code>)
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+
+							<h3>How to Show Hidden Files in FTP Clients</h3>
+							<p>Because <code>.htaccess</code> starts with <code>.</code>, it is a hidden file and may
+								not be visible by default in some FTP clients.</p>
+
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Client</th>
+											<th>How to Enable</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>FileZilla</td>
+											<td>"Server" menu → "Force showing hidden files"</td>
+										</tr>
+										<tr>
+											<td>Cyberduck</td>
+											<td>Preferences → "Browser" → "Show hidden files"</td>
+										</tr>
+										<tr>
+											<td>Server File Manager</td>
+											<td>Open "File Manager" from your hosting control panel and enable the "Show
+												hidden files" option</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
 					</section>
 
@@ -196,63 +320,129 @@
 
 					<!-- 問題のある記述の特定方法 -->
 					<section>
-						<h2>問題のある記述の特定方法</h2>
+						<div class="lang-block" data-lang="ja">
+							<h2>問題のある記述の特定方法</h2>
 
-						<h3>二分探索でのデバッグ</h3>
-						<p>記述量が多い場合は、コードを半分にコメントアウトして問題がどちらの半分にあるかを絞り込む方法が効率的。</p>
+							<h3>二分探索でのデバッグ</h3>
+							<p>記述量が多い場合は、コードを半分にコメントアウトして問題がどちらの半分にあるかを絞り込む方法が効率的。</p>
 
-						<pre class="article-code"><code># ファイル全体の半分をコメントアウトして確認
+							<pre class="article-code"><code># ファイル全体の半分をコメントアウトして確認
 # ↓ この行から下をまとめてコメントアウト
 
 # &lt;IfModule mod_headers.c&gt;
 #     Header always set ...
 # &lt;/IfModule&gt;</code></pre>
 
-						<h3>エラーログの確認</h3>
-						<p>サーバーのエラーログには 500 エラーの原因が記録されている。ホスティングの管理パネルから確認できる場合がある。</p>
+							<h3>エラーログの確認</h3>
+							<p>サーバーのエラーログには 500 エラーの原因が記録されている。ホスティングの管理パネルから確認できる場合がある。</p>
 
-						<p>よくあるエラーの例:</p>
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>エラーメッセージ</th>
-										<th>原因</th>
-										<th>対処</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>Invalid command 'Header'</code></td>
-										<td><code>mod_headers</code> が無効</td>
-										<td><code>&lt;IfModule mod_headers.c&gt;</code> でラップされているか確認。ホスティングに
-											<code>mod_headers</code> の有効化を問い合わせる
-										</td>
-									</tr>
-									<tr>
-										<td><code>Invalid command 'RewriteEngine'</code></td>
-										<td><code>mod_rewrite</code> が無効</td>
-										<td><code>&lt;IfModule mod_rewrite.c&gt;</code> でラップされているか確認</td>
-									</tr>
-									<tr>
-										<td><code>Options not allowed here</code></td>
-										<td>ホスティングが <code>Options</code> ディレクティブを制限している</td>
-										<td><code>Options -MultiViews -Indexes</code> 行を削除または <code>#</code> でコメントアウト
-										</td>
-									</tr>
-									<tr>
-										<td><code>AuthType not set</code></td>
-										<td>Basic 認証の設定が不完全</td>
-										<td><code>AuthType</code> / <code>AuthName</code> / <code>AuthUserFile</code>
-											がすべて揃っているか確認</td>
-									</tr>
-									<tr>
-										<td><code>Unable to open password file</code></td>
-										<td><code>.htpasswd</code> のパスが間違っている</td>
-										<td><code>AuthUserFile</code> に指定したフルパスが正しいか確認</td>
-									</tr>
-								</tbody>
-							</table>
+							<p>よくあるエラーの例:</p>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>エラーメッセージ</th>
+											<th>原因</th>
+											<th>対処</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td><code>Invalid command 'Header'</code></td>
+											<td><code>mod_headers</code> が無効</td>
+											<td><code>&lt;IfModule mod_headers.c&gt;</code> でラップされているか確認。ホスティングに
+												<code>mod_headers</code> の有効化を問い合わせる
+											</td>
+										</tr>
+										<tr>
+											<td><code>Invalid command 'RewriteEngine'</code></td>
+											<td><code>mod_rewrite</code> が無効</td>
+											<td><code>&lt;IfModule mod_rewrite.c&gt;</code> でラップされているか確認</td>
+										</tr>
+										<tr>
+											<td><code>Options not allowed here</code></td>
+											<td>ホスティングが <code>Options</code> ディレクティブを制限している</td>
+											<td><code>Options -MultiViews -Indexes</code> 行を削除または <code>#</code>
+												でコメントアウト
+											</td>
+										</tr>
+										<tr>
+											<td><code>AuthType not set</code></td>
+											<td>Basic 認証の設定が不完全</td>
+											<td><code>AuthType</code> / <code>AuthName</code> /
+												<code>AuthUserFile</code>
+												がすべて揃っているか確認</td>
+										</tr>
+										<tr>
+											<td><code>Unable to open password file</code></td>
+											<td><code>.htpasswd</code> のパスが間違っている</td>
+											<td><code>AuthUserFile</code> に指定したフルパスが正しいか確認</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>How to Identify the Problematic Entry</h2>
+
+							<h3>Binary Search Debugging</h3>
+							<p>When there is a lot of content, the most efficient approach is to comment out half the
+								file and narrow down which half contains the problem.</p>
+
+							<pre class="article-code"><code># Comment out the bottom half of the file to check
+# ↓ Comment out everything below this line
+
+# &lt;IfModule mod_headers.c&gt;
+#     Header always set ...
+# &lt;/IfModule&gt;</code></pre>
+
+							<h3>Checking the Error Log</h3>
+							<p>The cause of a 500 error is recorded in the server's error log. You may be able to access
+								it from your hosting control panel.</p>
+
+							<p>Common error examples:</p>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Error Message</th>
+											<th>Cause</th>
+											<th>Solution</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td><code>Invalid command 'Header'</code></td>
+											<td><code>mod_headers</code> is disabled</td>
+											<td>Check that it is wrapped in <code>&lt;IfModule mod_headers.c&gt;</code>.
+												Contact your host to enable <code>mod_headers</code></td>
+										</tr>
+										<tr>
+											<td><code>Invalid command 'RewriteEngine'</code></td>
+											<td><code>mod_rewrite</code> is disabled</td>
+											<td>Check that it is wrapped in <code>&lt;IfModule mod_rewrite.c&gt;</code>
+											</td>
+										</tr>
+										<tr>
+											<td><code>Options not allowed here</code></td>
+											<td>The hosting provider restricts the <code>Options</code> directive</td>
+											<td>Delete or comment out the <code>Options -MultiViews -Indexes</code> line
+											</td>
+										</tr>
+										<tr>
+											<td><code>AuthType not set</code></td>
+											<td>Basic Auth configuration is incomplete</td>
+											<td>Check that <code>AuthType</code>, <code>AuthName</code>, and
+												<code>AuthUserFile</code> are all present</td>
+										</tr>
+										<tr>
+											<td><code>Unable to open password file</code></td>
+											<td>The path to <code>.htpasswd</code> is incorrect</td>
+											<td>Verify the full path specified in <code>AuthUserFile</code></td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
 					</section>
 
@@ -260,40 +450,84 @@
 
 					<!-- やってはいけないこと -->
 					<section>
-						<h2>やってはいけないこと</h2>
+						<div class="lang-block" data-lang="ja">
+							<h2>やってはいけないこと</h2>
 
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										<th>NG 行為</th>
-										<th>理由</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>バックアップなしで <code>.htaccess</code> を直接編集する</td>
-										<td>失敗した際に戻せなくなる</td>
-									</tr>
-									<tr>
-										<td><code># BEGIN WordPress</code> 〜 <code># END WordPress</code> ブロック内を編集する
-										</td>
-										<td>WordPress がパーマリンク設定の保存時に自動上書きするため、変更が消える</td>
-									</tr>
-									<tr>
-										<td>プラグインが生成したブロック（Wordfence / EWWWIO 等）を手動で編集する</td>
-										<td>プラグインが上書きするため変更が消える。またプラグインが整合性チェックで誤動作する場合がある</td>
-									</tr>
-									<tr>
-										<td>本番環境でいきなり大量の設定を一括適用する</td>
-										<td>問題発生時に原因の特定が困難になる。設定は少しずつ追加してテストする</td>
-									</tr>
-									<tr>
-										<td><code>.htaccess</code> を完全に削除する</td>
-										<td>WordPress のパーマリンクが機能しなくなる。リネーム（<code>_htaccess</code> 等）で無効化するに留める</td>
-									</tr>
-								</tbody>
-							</table>
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>NG 行為</th>
+											<th>理由</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>バックアップなしで <code>.htaccess</code> を直接編集する</td>
+											<td>失敗した際に戻せなくなる</td>
+										</tr>
+										<tr>
+											<td><code># BEGIN WordPress</code> 〜 <code># END WordPress</code> ブロック内を編集する
+											</td>
+											<td>WordPress がパーマリンク設定の保存時に自動上書きするため、変更が消える</td>
+										</tr>
+										<tr>
+											<td>プラグインが生成したブロック（Wordfence / EWWWIO 等）を手動で編集する</td>
+											<td>プラグインが上書きするため変更が消える。またプラグインが整合性チェックで誤動作する場合がある</td>
+										</tr>
+										<tr>
+											<td>本番環境でいきなり大量の設定を一括適用する</td>
+											<td>問題発生時に原因の特定が困難になる。設定は少しずつ追加してテストする</td>
+										</tr>
+										<tr>
+											<td><code>.htaccess</code> を完全に削除する</td>
+											<td>WordPress のパーマリンクが機能しなくなる。リネーム（<code>_htaccess</code> 等）で無効化するに留める</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>What NOT to Do</h2>
+
+							<div class="table-wrap">
+								<table>
+									<thead>
+										<tr>
+											<th>Don't</th>
+											<th>Reason</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td>Edit <code>.htaccess</code> directly without a backup</td>
+											<td>You won't be able to revert if something goes wrong</td>
+										</tr>
+										<tr>
+											<td>Edit inside the <code># BEGIN WordPress</code> —
+												<code># END WordPress</code> block</td>
+											<td>WordPress overwrites this block automatically when saving permalink
+												settings, so your changes will be lost</td>
+										</tr>
+										<tr>
+											<td>Manually edit blocks generated by plugins (Wordfence, EWWW Image
+												Optimizer, etc.)</td>
+											<td>The plugin will overwrite your changes, and its integrity check may
+												cause unexpected behavior</td>
+										</tr>
+										<tr>
+											<td>Apply a large batch of settings all at once on a production site</td>
+											<td>It becomes difficult to identify the cause when a problem occurs. Add
+												settings incrementally and test each time</td>
+										</tr>
+										<tr>
+											<td>Completely delete <code>.htaccess</code></td>
+											<td>WordPress permalinks will stop working. Disable it by renaming (e.g. to
+												<code>_htaccess</code>) instead</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
 					</section>
 
@@ -301,32 +535,63 @@
 
 					<!-- WordPress のパーマリンク再設定 -->
 					<section>
-						<h2>リカバリ後の WordPress パーマリンク再設定</h2>
+						<div class="lang-block" data-lang="ja">
+							<h2>リカバリ後の WordPress パーマリンク再設定</h2>
 
-						<p>リカバリ手順でリネームした <code>.htaccess</code> を元に戻した後、WordPress が生成する <code># BEGIN WordPress</code>
-							ブロックが消えている場合はパーマリンクが機能しない。</p>
+							<p>リカバリ手順でリネームした <code>.htaccess</code> を元に戻した後、WordPress が生成する
+								<code># BEGIN WordPress</code>
+								ブロックが消えている場合はパーマリンクが機能しない。</p>
 
-						<h3>対処手順</h3>
-						<ol>
-							<li>WordPress 管理画面にログインする</li>
-							<li>「設定」→「パーマリンク」を開く</li>
-							<li>変更せず「変更を保存」ボタンをクリックする</li>
-							<li>WordPress が自動的に <code># BEGIN WordPress</code> ブロックを <code>.htaccess</code> に書き込む</li>
-						</ol>
+							<h3>対処手順</h3>
+							<ol>
+								<li>WordPress 管理画面にログインする</li>
+								<li>「設定」→「パーマリンク」を開く</li>
+								<li>変更せず「変更を保存」ボタンをクリックする</li>
+								<li>WordPress が自動的に <code># BEGIN WordPress</code> ブロックを <code>.htaccess</code> に書き込む
+								</li>
+							</ol>
 
-						<blockquote>
-							<p>カスタムルールは <code># BEGIN WordPress</code> ブロックの上（外）に記述する。ブロックの中に書くと WordPress
-								が自動上書きし、変更が消える。</p>
-						</blockquote>
+							<blockquote>
+								<p>カスタムルールは <code># BEGIN WordPress</code> ブロックの上（外）に記述する。ブロックの中に書くと WordPress
+									が自動上書きし、変更が消える。</p>
+							</blockquote>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>Re-configuring WordPress Permalinks After Recovery</h2>
+
+							<p>After renaming <code>.htaccess</code> back in the recovery procedure, if the
+								<code># BEGIN WordPress</code>
+								block generated by WordPress is missing, permalinks will not work.</p>
+
+							<h3>Steps to Fix</h3>
+							<ol>
+								<li>Log in to the WordPress admin panel</li>
+								<li>Go to "Settings" → "Permalinks"</li>
+								<li>Click "Save Changes" without making any changes</li>
+								<li>WordPress will automatically write the <code># BEGIN WordPress</code> block back
+									into <code>.htaccess</code></li>
+							</ol>
+
+							<blockquote>
+								<p>Always place custom rules above (outside of) the <code># BEGIN WordPress</code>
+									block. Placing them inside the block will cause WordPress to overwrite and erase
+									your changes.</p>
+							</blockquote>
+						</div>
 					</section>
 
 					<!-- 戻るリンク -->
 					<div class="article-back">
-						<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+						<div class="lang-block" data-lang="ja">
+							<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<a href="../" class="btn btn-secondary">← Back to Generator</a>
+						</div>
 					</div>
 
 					<aside class="license-notice">
-						<div>
+						<div class="lang-block" data-lang="ja">
 							<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja"
 								rel="nofollow noreferrer noopener" target="_blank">
 								<img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png"
@@ -343,6 +608,26 @@
 							<p>
 								&copy; 2026 まーちゅう（<a href="https://x.com/RocketMartue"
 									rel="nofollow noreferrer noopener" target="_blank">web-ya3.com</a>）
+							</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+								rel="nofollow noreferrer noopener" target="_blank">
+								<img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png"
+									alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+									width="88" height="31">
+							</a>
+							<p>
+								This content is licensed under
+								<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+									rel="nofollow noreferrer noopener" target="_blank">CC BY-NC-SA 4.0</a>.
+								<strong>Reproduction in paid online courses or paid educational materials is
+									prohibited.</strong>
+								See the <a href="/terms" rel="nofollow noreferrer">Terms of Use</a> for details.
+							</p>
+							<p>
+								&copy; 2026 Machu (<a href="https://x.com/RocketMartue"
+									rel="nofollow noreferrer noopener" target="_blank">web-ya3.com</a>)
 							</p>
 						</div>
 					</aside>


### PR DESCRIPTION
## 概要

Issue #79 — `recovery-guide/index.html` の i18n 化。
htaccess-basics-guide・directives-guide で確立した **dual-language ブロック方式** を適用し、日本語 / 英語の言語切替に対応させる。

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `recovery-guide/index.html` | head の i18n 属性・hreflang 3 件追加、lang-toggle ボタン挿入、5 section の lang-block 化、`.article-back` / `.license-notice` の lang-block 化 |
| `assets/js/locales/ja.js` | `guide.recovery.*` キー 5 件追加 |
| `assets/js/locales/en.js` | `guide.recovery.*` キー 5 件追加 |

---

## 変更詳細

### `<head>` の i18n 対応
- `<meta name="description">` / `og:title` / `og:description` / `og:url` / `og:locale` / `twitter:title` / `twitter:description` に `data-i18n-content` 属性追加
- `<title>` に `data-i18n` 属性追加
- hreflang alternate 3 件（`ja` / `en` / `x-default`）追加

### chrome の i18n 化
- skip-link に `data-i18n="skip.link"` 追加
- サブタイトル `<p>` に `data-i18n="guide.recovery.subtitle"` 追加
- lang-toggle ボタンを `.header-actions` 先頭に追加（他ガイドと同形）
- `<nav>` に `data-i18n-aria-label="nav.aria"` 追加

### article 本文
全 5 section を ja/en lang-block で包み、英語訳を新規執筆：

1. 設定を変える前に必ずバックアップ → **Back Up Before Making Changes**
2. FTP / ファイルマネージャーでのリカバリ手順 → **Recovery Steps via FTP / File Manager**
3. 問題のある記述の特定方法 → **How to Identify the Problematic Entry**
4. やってはいけないこと → **What NOT to Do**
5. リカバリ後の WordPress パーマリンク再設定 → **Re-configuring WordPress Permalinks After Recovery**

コード内の日本語コメントは英語版で英訳に差し替え済み。

### `.article-back` / `.license-notice`
- ja/en lang-block 化。英語版 CC リンクは canonical URL（`deed.en` なし）。

### ロケールキー
- `guide.recovery.subtitle` / `title` / `description` / `ogUrl` / `ogLocale` を `ja.js` / `en.js` に追加。

---

## 編集しないもの

- `_headers`（インラインスクリプト変更なし → CSP ハッシュ再計算不要）
- `assets/js/guide.js` / `assets/js/i18n.js`
- `assets/scss/` （`.lang-block[hidden]` ルール既存）

---

## チェックリスト

- [x] `data-lang="ja"` と `data-lang="en"` の個数が一致（各 7 個）
- [x] `guide.js` の読み込みが `</body>` 直前に存在することを確認（変更なし）
- [x] インラインスクリプト（ダークモード初期化）は一字一句変更なし
- [x] `ja.js` / `en.js` 双方にキー追加済み

Closes #79