### PR TITLE
feat: terms/index.html に i18n（日英切り替え）を実装

### DIFF
--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -254,4 +254,9 @@ export default {
 	'guide.recovery.description': 'A guide explaining FTP recovery procedures and troubleshooting when a .htaccess misconfiguration causes a 500 error.',
 	'guide.recovery.ogUrl': 'https://htaccess-generator-b46.pages.dev/recovery-guide/?lang=en',
 	'guide.recovery.ogLocale': 'en_US',
+	'guide.terms.subtitle': 'Terms of Use',
+	'guide.terms.title': 'Terms of Use | .htaccess Generator',
+	'guide.terms.description': 'Terms of Use for .htaccess Generator. Covers conditions for using generated .htaccess files, the CC BY-NC-SA 4.0 license of the documentation content, and prohibited uses.',
+	'guide.terms.ogUrl': 'https://htaccess-generator-b46.pages.dev/terms/?lang=en',
+	'guide.terms.ogLocale': 'en_US',
 };

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -254,4 +254,9 @@ export default {
 	'guide.recovery.description': '.htaccess の設定ミスで 500 エラーが発生した場合の FTP リカバリ手順とトラブルシューティングを解説するガイド',
 	'guide.recovery.ogUrl': 'https://htaccess-generator-b46.pages.dev/recovery-guide/',
 	'guide.recovery.ogLocale': 'ja_JP',
+	'guide.terms.subtitle': '利用規約',
+	'guide.terms.title': '利用規約 | .htaccess Generator',
+	'guide.terms.description': '.htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。',
+	'guide.terms.ogUrl': 'https://htaccess-generator-b46.pages.dev/terms/',
+	'guide.terms.ogLocale': 'ja_JP',
 };

--- a/terms/index.html
+++ b/terms/index.html
@@ -5,30 +5,37 @@
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description"
-			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。">
+			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。"
+			data-i18n-content="guide.terms.description">
 		<meta name="license" content="https://creativecommons.org/licenses/by-nc-sa/4.0/">
 		<!-- OGP -->
 		<meta property="og:type" content="article">
-		<meta property="og:title" content="利用規約">
+		<meta property="og:title" content="利用規約" data-i18n-content="guide.terms.subtitle">
 		<meta property="og:description"
-			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。">
+			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。"
+			data-i18n-content="guide.terms.description">
 		<meta property="og:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 		<meta property="og:image:width" content="1200">
 		<meta property="og:image:height" content="630">
-		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/terms/">
-		<meta property="og:locale" content="ja_JP">
+		<meta property="og:url" content="https://htaccess-generator-b46.pages.dev/terms/"
+			data-i18n-content="guide.terms.ogUrl">
+		<meta property="og:locale" content="ja_JP" data-i18n-content="guide.terms.ogLocale">
 		<meta property="og:site_name" content=".htaccess Generator">
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image">
-		<meta name="twitter:title" content="利用規約">
+		<meta name="twitter:title" content="利用規約" data-i18n-content="guide.terms.subtitle">
 		<meta name="twitter:description"
-			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。">
+			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。"
+			data-i18n-content="guide.terms.description">
 		<meta name="twitter:image"
 			content="https://htaccess-generator-b46.pages.dev/assets/images/htaccess-generator-ogp.png">
 
 		<link rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-		<title>利用規約 | .htaccess Generator</title>
+		<link rel="alternate" hreflang="ja" href="https://htaccess-generator-b46.pages.dev/terms/">
+		<link rel="alternate" hreflang="en" href="https://htaccess-generator-b46.pages.dev/terms/?lang=en">
+		<link rel="alternate" hreflang="x-default" href="https://htaccess-generator-b46.pages.dev/terms/">
+		<title data-i18n="guide.terms.title">利用規約 | .htaccess Generator</title>
 		<script>
 			try {
 				if (window.localStorage && localStorage.getItem('htaccess-theme') === 'dark') {
@@ -46,13 +53,18 @@
 	</head>
 
 	<body>
-		<a href="#main-content" class="skip-link">メインコンテンツへスキップ</a>
+		<a href="#main-content" class="skip-link" data-i18n="skip.link">メインコンテンツへスキップ</a>
 		<div class="app-wrapper">
 
 			<header class="app-header">
 				<h1><a href="../">.htaccess Generator</a><span class="h1-sub">for WordPress</span></h1>
-				<p>利用規約</p>
+				<p data-i18n="guide.terms.subtitle">利用規約</p>
 				<div class="header-actions">
+					<button type="button" class="lang-toggle-btn" aria-label="言語切り替え（Switch to English）"
+						data-i18n-aria-label="lang.btn.label">
+						<span class="lang-toggle-icon" aria-hidden="true">🌐</span>
+						<span class="lang-toggle-label" data-i18n="lang.btn.text">EN</span>
+					</button>
 					<button type="button" class="theme-toggle-btn" aria-label="ダークモードに切り替え" aria-pressed="false">
 						<span class="theme-toggle-icon" aria-hidden="true">🌙</span>
 						<span class="theme-toggle-label">ダーク</span>
@@ -66,15 +78,15 @@
 				</div>
 			</header>
 
-			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション">
+			<nav class="site-nav" id="site-nav-menu" hidden aria-label="サイトナビゲーション" data-i18n-aria-label="nav.aria">
 				<div class="site-nav-card">
 					<ul class="site-nav-list">
 						<li><a href="../"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14"
-									height="14" fill="currentColor" aria-hidden="true"
-									style="vertical-align:-0.125em;margin-right:0.3em">
-									<path fill-rule="evenodd"
-										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
+								height="14" fill="currentColor" aria-hidden="true"
+								style="vertical-align:-0.125em;margin-right:0.3em">
+								<path fill-rule="evenodd"
+									d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
+							</svg>ジェネレーター</a></li>
 						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
 						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
 						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
@@ -97,74 +109,137 @@
 				<article class="card article">
 
 					<section>
-						<h2>1. サービスについて</h2>
-						<p>本サービス（htaccess-generator-b46.pages.dev、以下「本サイト」）は、WordPress 向け .htaccess
-							ファイルの生成を支援する無償ツールです。WordPress コミュニティへの貢献を目的として、まーちゅう（@RocketMartue）が個人で運営・提供しています。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>1. サービスについて</h2>
+							<p>本サービス（htaccess-generator-b46.pages.dev、以下「本サイト」）は、WordPress 向け .htaccess
+								ファイルの生成を支援する無償ツールです。WordPress コミュニティへの貢献を目的として、まーちゅう（@RocketMartue）が個人で運営・提供しています。</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>1. About This Service</h2>
+							<p>This service (htaccess-generator-b46.pages.dev, hereinafter "the Site") is a free tool that helps generate .htaccess files for WordPress. It is operated and provided individually by Machu (@RocketMartue) as a contribution to the WordPress community.</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>2. 生成された .htaccess の利用について</h2>
-						<p>本サイトで生成された .htaccess の内容は、商用・非商用を問わず自由にご利用いただけます。クレジット表記も不要です。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>2. 生成された .htaccess の利用について</h2>
+							<p>本サイトで生成された .htaccess の内容は、商用・非商用を問わず自由にご利用いただけます。クレジット表記も不要です。</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>2. Use of Generated .htaccess Files</h2>
+							<p>The content of .htaccess files generated on the Site may be used freely for both commercial and non-commercial purposes. Attribution is not required.</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>3. 本サービス自体の利用制限（禁止事項）</h2>
-						<ul>
-							<li>本サイトを有償サービスの一部として再提供すること</li>
-							<li>本サイトを iframe 等で自社の有償プロダクトに埋め込むこと</li>
-							<li>本サイトへのアクセスを対価として金銭その他の利益を得ること</li>
-							<li>fork したソースコードを機能的に同等の有償サービスとして提供すること</li>
-						</ul>
+						<div class="lang-block" data-lang="ja">
+							<h2>3. 本サービス自体の利用制限（禁止事項）</h2>
+							<ul>
+								<li>本サイトを有償サービスの一部として再提供すること</li>
+								<li>本サイトを iframe 等で自社の有償プロダクトに埋め込むこと</li>
+								<li>本サイトへのアクセスを対価として金銭その他の利益を得ること</li>
+								<li>fork したソースコードを機能的に同等の有償サービスとして提供すること</li>
+							</ul>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>3. Restrictions on Use of This Service (Prohibited Acts)</h2>
+							<ul>
+								<li>Redistributing the Site as part of a paid service.</li>
+								<li>Embedding the Site via iframe or similar into your paid products.</li>
+								<li>Monetizing access to the Site.</li>
+								<li>Offering a functionally equivalent paid service derived from the forked source code.</li>
+							</ul>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>4. ソースコードのライセンス</h2>
-						<p>MIT ライセンス（<a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
-								rel="noopener noreferrer">GitHub: rocket-martue/htaccess-generator</a>）</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>4. ソースコードのライセンス</h2>
+							<p>MIT ライセンス（<a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
+									rel="noopener noreferrer">GitHub: rocket-martue/htaccess-generator</a>）</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>4. Source Code License</h2>
+							<p>MIT License (<a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
+									rel="noopener noreferrer">GitHub: rocket-martue/htaccess-generator</a>)</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>5. 免責事項</h2>
-						<p>現状有姿で提供。生成された .htaccess 利用により生じた損害に対して運営者は責任を負わない。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>5. 免責事項</h2>
+							<p>現状有姿で提供。生成された .htaccess 利用により生じた損害に対して運営者は責任を負わない。</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>5. Disclaimer</h2>
+							<p>Provided as-is. The operator assumes no responsibility for any damages arising from the use of generated .htaccess files.</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>6. 変更</h2>
-						<p>本規約は予告なく変更される可能性がある。</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>6. 変更</h2>
+							<p>本規約は予告なく変更される可能性がある。</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>6. Changes</h2>
+							<p>These terms may be changed without prior notice.</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>7. 解説コンテンツのライセンス</h2>
-						<p>解説記事・ガイド・図表などのドキュメントコンテンツは <a
-								href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja" target="_blank"
-								rel="noopener noreferrer">CC BY-NC-SA 4.0</a> の下で提供。</p>
-						<p><strong>許可される利用</strong>: ブログ・個人学習ノートでの引用（出典明記）、社内勉強会、非営利の教育目的</p>
-						<p><strong>禁止される利用</strong>: Udemy 等の有料オンライン講座での教材利用、有料書籍・有料 note 記事への転載、生成 AI の学習データとしての商用利用
-						</p>
+						<div class="lang-block" data-lang="ja">
+							<h2>7. 解説コンテンツのライセンス</h2>
+							<p>解説記事・ガイド・図表などのドキュメントコンテンツは <a
+									href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja" target="_blank"
+									rel="noopener noreferrer">CC BY-NC-SA 4.0</a> の下で提供。</p>
+							<p><strong>許可される利用</strong>: ブログ・個人学習ノートでの引用（出典明記）、社内勉強会、非営利の教育目的</p>
+							<p><strong>禁止される利用</strong>: Udemy 等の有料オンライン講座での教材利用、有料書籍・有料 note 記事への転載、生成 AI の学習データとしての商用利用
+							</p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>7. Documentation Content License</h2>
+							<p>The documentation content, including explanatory articles, guides, and diagrams, is provided under <a
+									href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank"
+									rel="noopener noreferrer">CC BY-NC-SA 4.0</a>.</p>
+							<p><strong>Permitted</strong>: Quotation in blogs and personal study notes (with attribution), internal study sessions, non-commercial educational purposes.</p>
+							<p><strong>Prohibited</strong>: Use as teaching material in paid online courses such as Udemy, republication in paid books or paid note articles, commercial use as training data for generative AI.</p>
+						</div>
 					</section>
 
 					<hr class="divider">
 
 					<section>
-						<h2>8. お問い合わせ</h2>
-						<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a></p>
+						<div class="lang-block" data-lang="ja">
+							<h2>8. お問い合わせ</h2>
+							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a></p>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<h2>8. Contact</h2>
+							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a></p>
+						</div>
 					</section>
 
 					<!-- 戻るリンク -->
 					<div class="article-back">
-						<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
+						<div class="lang-block" data-lang="ja">
+							<a href="../" class="btn btn-secondary">&larr; ジェネレーターに戻る</a>
+						</div>
+						<div class="lang-block" data-lang="en" hidden>
+							<a href="../" class="btn btn-secondary">&larr; Back to Generator</a>
+						</div>
 					</div>
 
 				</article>

--- a/terms/index.html
+++ b/terms/index.html
@@ -10,7 +10,7 @@
 		<meta name="license" content="https://creativecommons.org/licenses/by-nc-sa/4.0/">
 		<!-- OGP -->
 		<meta property="og:type" content="article">
-		<meta property="og:title" content="利用規約" data-i18n-content="guide.terms.subtitle">
+		<meta property="og:title" content="利用規約 | .htaccess Generator" data-i18n-content="guide.terms.title">
 		<meta property="og:description"
 			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。"
 			data-i18n-content="guide.terms.description">
@@ -24,7 +24,7 @@
 		<meta property="og:site_name" content=".htaccess Generator">
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image">
-		<meta name="twitter:title" content="利用規約" data-i18n-content="guide.terms.subtitle">
+		<meta name="twitter:title" content="利用規約 | .htaccess Generator" data-i18n-content="guide.terms.title">
 		<meta name="twitter:description"
 			content=".htaccess Generator の利用規約。生成した .htaccess の利用条件、解説コンテンツのライセンス（CC BY-NC-SA 4.0）、禁止事項について説明します。"
 			data-i18n-content="guide.terms.description">
@@ -82,11 +82,11 @@
 				<div class="site-nav-card">
 					<ul class="site-nav-list">
 						<li><a href="../"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14"
-								height="14" fill="currentColor" aria-hidden="true"
-								style="vertical-align:-0.125em;margin-right:0.3em">
-								<path fill-rule="evenodd"
-									d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-							</svg>ジェネレーター</a></li>
+									height="14" fill="currentColor" aria-hidden="true"
+									style="vertical-align:-0.125em;margin-right:0.3em">
+									<path fill-rule="evenodd"
+										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
+								</svg>ジェネレーター</a></li>
 						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
 						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
 						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
@@ -116,7 +116,9 @@
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>1. About This Service</h2>
-							<p>This service (htaccess-generator-b46.pages.dev, hereinafter "the Site") is a free tool that helps generate .htaccess files for WordPress. It is operated and provided individually by Machu (@RocketMartue) as a contribution to the WordPress community.</p>
+							<p>This service (htaccess-generator-b46.pages.dev, hereinafter "the Site") is a free tool
+								that helps generate .htaccess files for WordPress. It is operated and provided
+								individually by Machu (@RocketMartue) as a contribution to the WordPress community.</p>
 						</div>
 					</section>
 
@@ -129,7 +131,8 @@
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>2. Use of Generated .htaccess Files</h2>
-							<p>The content of .htaccess files generated on the Site may be used freely for both commercial and non-commercial purposes. Attribution is not required.</p>
+							<p>The content of .htaccess files generated on the Site may be used freely for both
+								commercial and non-commercial purposes. Attribution is not required.</p>
 						</div>
 					</section>
 
@@ -151,7 +154,8 @@
 								<li>Redistributing the Site as part of a paid service.</li>
 								<li>Embedding the Site via iframe or similar into your paid products.</li>
 								<li>Monetizing access to the Site.</li>
-								<li>Offering a functionally equivalent paid service derived from the forked source code.</li>
+								<li>Offering a functionally equivalent paid service derived from the forked source code.
+								</li>
 							</ul>
 						</div>
 					</section>
@@ -166,8 +170,9 @@
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>4. Source Code License</h2>
-							<p>MIT License (<a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
-									rel="noopener noreferrer">GitHub: rocket-martue/htaccess-generator</a>)</p>
+							<p>MIT License (<a href="https://github.com/rocket-martue/htaccess-generator"
+									target="_blank" rel="noopener noreferrer">GitHub:
+									rocket-martue/htaccess-generator</a>)</p>
 						</div>
 					</section>
 
@@ -180,7 +185,8 @@
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>5. Disclaimer</h2>
-							<p>Provided as-is. The operator assumes no responsibility for any damages arising from the use of generated .htaccess files.</p>
+							<p>Provided as-is. The operator assumes no responsibility for any damages arising from the
+								use of generated .htaccess files.</p>
 						</div>
 					</section>
 
@@ -206,16 +212,20 @@
 									href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja" target="_blank"
 									rel="noopener noreferrer">CC BY-NC-SA 4.0</a> の下で提供。</p>
 							<p><strong>許可される利用</strong>: ブログ・個人学習ノートでの引用（出典明記）、社内勉強会、非営利の教育目的</p>
-							<p><strong>禁止される利用</strong>: Udemy 等の有料オンライン講座での教材利用、有料書籍・有料 note 記事への転載、生成 AI の学習データとしての商用利用
+							<p><strong>禁止される利用</strong>: Udemy 等の有料オンライン講座での教材利用、有料書籍・有料 note 記事への転載、生成 AI
+								の学習データとしての商用利用
 							</p>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>7. Documentation Content License</h2>
-							<p>The documentation content, including explanatory articles, guides, and diagrams, is provided under <a
-									href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank"
-									rel="noopener noreferrer">CC BY-NC-SA 4.0</a>.</p>
-							<p><strong>Permitted</strong>: Quotation in blogs and personal study notes (with attribution), internal study sessions, non-commercial educational purposes.</p>
-							<p><strong>Prohibited</strong>: Use as teaching material in paid online courses such as Udemy, republication in paid books or paid note articles, commercial use as training data for generative AI.</p>
+							<p>The documentation content, including explanatory articles, guides, and diagrams, is
+								provided under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+									target="_blank" rel="noopener noreferrer">CC BY-NC-SA 4.0</a>.</p>
+							<p><strong>Permitted</strong>: Quotation in blogs and personal study notes (with
+								attribution), internal study sessions, non-commercial educational purposes.</p>
+							<p><strong>Prohibited</strong>: Use as teaching material in paid online courses such as
+								Udemy, republication in paid books or paid note articles, commercial use as training
+								data for generative AI.</p>
 						</div>
 					</section>
 
@@ -224,11 +234,13 @@
 					<section>
 						<div class="lang-block" data-lang="ja">
 							<h2>8. お問い合わせ</h2>
-							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a></p>
+							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a>
+							</p>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
 							<h2>8. Contact</h2>
-							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a></p>
+							<p><a href="https://web-ya3.com" target="_blank" rel="noopener noreferrer">web-ya3.com</a>
+							</p>
 						</div>
 					</section>
 

--- a/terms/index.html
+++ b/terms/index.html
@@ -94,7 +94,7 @@
 						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
 						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/">リカバリ方法</a></li>
-						<li><a href="../terms/" aria-current="page">利用規約</a></li>
+						<li><a href="../terms/" aria-current="page" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"
 									viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"
@@ -247,10 +247,10 @@
 					<!-- 戻るリンク -->
 					<div class="article-back">
 						<div class="lang-block" data-lang="ja">
-							<a href="../" class="btn btn-secondary">&larr; ジェネレーターに戻る</a>
+							<a href="../" class="btn btn-secondary">← ジェネレーターに戻る</a>
 						</div>
 						<div class="lang-block" data-lang="en" hidden>
-							<a href="../" class="btn btn-secondary">&larr; Back to Generator</a>
+							<a href="../" class="btn btn-secondary">← Back to Generator</a>
 						</div>
 					</div>
 


### PR DESCRIPTION
## 概要

Close #94

`terms/index.html` に i18n（日英デュアル言語ブロック）対応を実装。`recovery-guide/index.html`（PR #92）および `wp-protection-guide/index.html`（PR #93）と同一パターン。

---

## 変更内容

### `terms/index.html`

- 全 8 セクションを `.lang-block[data-lang="ja"]` + `.lang-block[data-lang="en" hidden]` のデュアルブロックに変換
- `<header>` に `lang-toggle-btn` を追加
- `<nav>` に `data-i18n-aria-label="nav.aria"` を追加
- `<head>` に `hreflang` alternate リンクを追加（ja / en / x-default）
- meta description / OGP / Twitter Card に `data-i18n-content` 属性を追加
- `<title>` に `data-i18n="guide.terms.title"` を追加
- `article-back` リンクもデュアルブロック化（← ジェネレーターに戻る / ← Back to Generator）

### `assets/js/locales/ja.js`

- `guide.terms.*` キー 5 件を追加（subtitle / title / description / ogUrl / ogLocale）

### `assets/js/locales/en.js`

- `guide.terms.*` キー 5 件を追加（subtitle / title / description / ogUrl / ogLocale）

---

## CSP ハッシュ

インラインスクリプトの内容は変更なし。ハッシュ `sha256-GBJqAOUErbfcfWI/UoSYXeqztiSO1id94mkuBZNKM/w=` は維持されており、`_headers` の更新は不要。

---

## チェックリスト

- [x] インラインスクリプトのハッシュを確認済み（変更なし）
- [x] `lang-block` パターンが recovery-guide / wp-protection-guide と同一
- [x] CC BY-NC-SA 4.0 リンク: ja ブロックは `/deed.ja`、en ブロックは正規 URL（`/licenses/by-nc-sa/4.0/`）