### PR TITLE
feat: ナビリンクテキストの i18n 化 (#97)

### DIFF
--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -7,6 +7,14 @@ export default {
 	'nav.open': 'Open menu',
 	'nav.close': 'Close menu',
 	'nav.aria': 'Site navigation',
+	'nav.generator': 'Generator',
+	'nav.basics': '.htaccess Basics',
+	'nav.directives': 'Directives',
+	'nav.securityHeaders': 'Security Headers',
+	'nav.cache': 'Cache & Performance',
+	'nav.wpProtection': 'wp-admin Protection',
+	'nav.options': 'Options & ErrorDocument',
+	'nav.recovery': 'Recovery',
 	'nav.terms': 'Terms of Use',
 
 	// Header

--- a/assets/js/locales/en.js
+++ b/assets/js/locales/en.js
@@ -13,7 +13,6 @@ export default {
 	'nav.securityHeaders': 'Security Headers',
 	'nav.cache': 'Cache & Performance',
 	'nav.wpProtection': 'wp-admin Protection',
-	'nav.options': 'Options & ErrorDocument',
 	'nav.recovery': 'Recovery',
 	'nav.terms': 'Terms of Use',
 

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -7,6 +7,14 @@ export default {
 	'nav.open': 'メニューを開く',
 	'nav.close': 'メニューを閉じる',
 	'nav.aria': 'サイトナビゲーション',
+	'nav.generator': 'ジェネレーター',
+	'nav.basics': '.htaccess 入門',
+	'nav.directives': 'ディレクティブ解説',
+	'nav.securityHeaders': 'セキュリティヘッダー',
+	'nav.cache': 'キャッシュ & パフォーマンス',
+	'nav.wpProtection': 'wp-admin 保護',
+	'nav.options': 'Options & ErrorDocument',
+	'nav.recovery': 'リカバリ方法',
 	'nav.terms': '利用規約',
 
 	// ヘッダー

--- a/assets/js/locales/ja.js
+++ b/assets/js/locales/ja.js
@@ -13,7 +13,6 @@ export default {
 	'nav.securityHeaders': 'セキュリティヘッダー',
 	'nav.cache': 'キャッシュ & パフォーマンス',
 	'nav.wpProtection': 'wp-admin 保護',
-	'nav.options': 'Options & ErrorDocument',
 	'nav.recovery': 'リカバリ方法',
 	'nav.terms': '利用規約',
 

--- a/cache-performance-guide/index.html
+++ b/cache-performance-guide/index.html
@@ -90,14 +90,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/" aria-current="page">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" aria-current="page" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/cache-performance-guide/index.html
+++ b/cache-performance-guide/index.html
@@ -96,7 +96,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" aria-current="page" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/directives-guide/index.html
+++ b/directives-guide/index.html
@@ -89,7 +89,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/directives-guide/index.html
+++ b/directives-guide/index.html
@@ -83,14 +83,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/" aria-current="page">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" aria-current="page" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -91,7 +91,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/htaccess-basics-guide/index.html
+++ b/htaccess-basics-guide/index.html
@@ -85,14 +85,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/" aria-current="page">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" aria-current="page" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/index.html
+++ b/index.html
@@ -75,14 +75,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 						<li><a href="security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/options-errordocument-guide/index.html
+++ b/options-errordocument-guide/index.html
@@ -88,15 +88,15 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
 						<li><a href="../options-errordocument-guide/" aria-current="page">Options &amp;
 								ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/options-errordocument-guide/index.html
+++ b/options-errordocument-guide/index.html
@@ -94,8 +94,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" aria-current="page">Options &amp;
-								ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/" aria-current="page">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/recovery-guide/index.html
+++ b/recovery-guide/index.html
@@ -89,7 +89,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" aria-current="page" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/recovery-guide/index.html
+++ b/recovery-guide/index.html
@@ -83,15 +83,15 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/" aria-current="page">リカバリ方法</a></li>
-						<li><a href="../terms/">利用規約</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" aria-current="page" data-i18n="nav.recovery">リカバリ方法</a></li>
+						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"
 									viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"

--- a/security-headers-guide/index.html
+++ b/security-headers-guide/index.html
@@ -91,7 +91,7 @@
 						<li><a href="../security-headers-guide/" aria-current="page" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/security-headers-guide/index.html
+++ b/security-headers-guide/index.html
@@ -85,14 +85,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/" aria-current="page">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" aria-current="page" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/terms/index.html
+++ b/terms/index.html
@@ -86,14 +86,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" aria-current="page" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"

--- a/terms/index.html
+++ b/terms/index.html
@@ -92,7 +92,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" aria-current="page" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/wp-protection-guide/index.html
+++ b/wp-protection-guide/index.html
@@ -95,7 +95,7 @@
 						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
 						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
 						<li><a href="../wp-protection-guide/" aria-current="page" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
 						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"

--- a/wp-protection-guide/index.html
+++ b/wp-protection-guide/index.html
@@ -89,14 +89,14 @@
 									style="vertical-align:-0.125em;margin-right:0.3em">
 									<path fill-rule="evenodd"
 										d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-								</svg>ジェネレーター</a></li>
-						<li><a href="../htaccess-basics-guide/">.htaccess 入門</a></li>
-						<li><a href="../directives-guide/">ディレクティブ解説</a></li>
-						<li><a href="../security-headers-guide/">セキュリティヘッダー</a></li>
-						<li><a href="../cache-performance-guide/">キャッシュ &amp; パフォーマンス</a></li>
-						<li><a href="../wp-protection-guide/" aria-current="page">wp-admin 保護</a></li>
-						<li><a href="../options-errordocument-guide/">Options &amp; ErrorDocument</a></li>
-						<li><a href="../recovery-guide/">リカバリ方法</a></li>
+								</svg><span data-i18n="nav.generator">ジェネレーター</span></a></li>
+						<li><a href="../htaccess-basics-guide/" data-i18n="nav.basics">.htaccess 入門</a></li>
+						<li><a href="../directives-guide/" data-i18n="nav.directives">ディレクティブ解説</a></li>
+						<li><a href="../security-headers-guide/" data-i18n="nav.securityHeaders">セキュリティヘッダー</a></li>
+						<li><a href="../cache-performance-guide/" data-i18n="nav.cache">キャッシュ &amp; パフォーマンス</a></li>
+						<li><a href="../wp-protection-guide/" aria-current="page" data-i18n="nav.wpProtection">wp-admin 保護</a></li>
+						<li><a href="../options-errordocument-guide/" data-i18n="nav.options">Options &amp; ErrorDocument</a></li>
+						<li><a href="../recovery-guide/" data-i18n="nav.recovery">リカバリ方法</a></li>
 						<li><a href="../terms/" data-i18n="nav.terms">利用規約</a></li>
 						<li><a href="https://github.com/rocket-martue/htaccess-generator" target="_blank"
 								rel="noopener noreferrer">GitHub <svg xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## 概要

#97 対応。全ページ共通のサイドナビゲーション内リンクテキストを多言語化（日本語 / 英語）する。

## 変更内容

### ロケールファイル
- `assets/js/locales/ja.js` — `nav.generator` / `nav.basics` / `nav.directives` / `nav.securityHeaders` / `nav.cache` / `nav.wpProtection` / `nav.recovery` の 7 キーを追加
- `assets/js/locales/en.js` — 同 7 キーの英語訳を追加
- `nav.options`（`Options & ErrorDocument`）は日英同一テキストのため翻訳対象から除外

### HTML（全 9 ページ）
- `index.html`
- `htaccess-basics-guide/index.html`
- `directives-guide/index.html`
- `security-headers-guide/index.html`
- `cache-performance-guide/index.html`
- `wp-protection-guide/index.html`
- `options-errordocument-guide/index.html`
- `recovery-guide/index.html`
- `terms/index.html`

各ページの `site-nav-list` 内リンクテキストに `data-i18n` を付与。

#### 実装方針
- **ジェネレーターリンク**（SVG アイコンあり）: SVG を壊さないようテキスト部のみ `<span data-i18n>` で包む
- **その他のリンク**: `<a>` に直接 `data-i18n` を付与
- **GitHub リンク・Options &amp; ErrorDocument**: 言語非依存のため対象外

## 動作確認項目

- [ ] 言語切替後にナビが英語表示されること
- [ ] リロード後・`?lang=en` 直接アクセスでもナビが英語表示されること
- [ ] アイコン（SVG）が翻訳で壊れていないこと
- [ ] ダークモード切替と干渉しないこと

Closes #97