### PR TITLE
fix: `_redirects` を削除（Cloudflare Pages はクエリパラメータマッチング非対応）

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,9 +1,0 @@
-/?lang=en                               /en/                                    301
-/htaccess-basics-guide/?lang=en         /en/htaccess-basics-guide/              301
-/directives-guide/?lang=en              /en/directives-guide/                   301
-/options-errordocument-guide/?lang=en   /en/options-errordocument-guide/        301
-/security-headers-guide/?lang=en        /en/security-headers-guide/             301
-/cache-performance-guide/?lang=en       /en/cache-performance-guide/            301
-/wp-protection-guide/?lang=en           /en/wp-protection-guide/               301
-/recovery-guide/?lang=en                /en/recovery-guide/                     301
-/terms/?lang=en                         /en/terms/                              301


### PR DESCRIPTION
Closes #105

## 変更内容

`_redirects` を削除。

## 背景

PR #104 で追加した `_redirects` は、source 側にクエリパラメータ条件（`?lang=en`）を使用していたが、Cloudflare Pages はこの書式をサポートしていない（[公式ドキュメント](https://developers.cloudflare.com/pages/configuration/redirects/) — Query Parameters = ❌）。

全 9 行が無効になっており、意図した 301 リダイレクトは発生していなかった。

## 判断の根拠

- プロジェクト内に `?lang=en` を生成するコードはすでに存在しない（PR #104 で URL 物理分離方式に移行済み）
- 言語切り替えボタンは `<a href="/en/...">` の直接リンクで実装されており、`_redirects` に依存しない
- 旧 URL 形式は PR #104 以前の動的切り替え時代のもので、外部に広く出回っている可能性は低い

## 変更ファイル

- `_redirects` — 削除

## チェックリスト

- [x] 言語切り替えボタン（🌐）が `/` ↔ `/en/` および全ガイドページで正常に遷移する
- [ ] Cloudflare Pages デプロイ後、`/` ・`/en/` 直接アクセスで意図しないリダイレクトが発生しない
